### PR TITLE
DOCS: adding plugin description content

### DIFF
--- a/description.md
+++ b/description.md
@@ -30,3 +30,7 @@ Follow the instructions in the [AppMap documentation](https://appland.com/docs) 
 # About AppMap
 
 Visit the [AppMap documentation](https://appland.com/docs/get-started.html#what-is-appmap) to learn how AppMap works and how it accelerates development processes.
+
+# FAQ
+
+Visit the [AppMap FAQ](https://appland.com/docs/faq.html).

--- a/description.md
+++ b/description.md
@@ -34,9 +34,7 @@ Follow the instructions in the [AppMap documentation](https://appland.com/docs) 
 
 # About AppMap
 
-Visit the [AppMap documentation](https://appland.com/docs/get-started.html#what-is-appmap) to learn how AppMap works and how it accelerates development processes.
-
-- [Blog](https://dev.to/appland)
+Visit the [AppMap documentation](https://appland.com/docs/get-started.html#what-is-appmap) and [AppLand blog](https://dev.to/appland) to learn how AppMap works and how it accelerates development processes.
 
 **Twitter**
 - [AppMap Ruby](https://twitter.com/appmapruby)

--- a/description.md
+++ b/description.md
@@ -31,6 +31,13 @@ Follow the instructions in the [AppMap documentation](https://appland.com/docs) 
 
 Visit the [AppMap documentation](https://appland.com/docs/get-started.html#what-is-appmap) to learn how AppMap works and how it accelerates development processes.
 
+- [Blog](https://dev.to/appland)
+
+**Twitter**
+- [AppMap Ruby](https://twitter.com/appmapruby)
+- [AppMap Python](https://twitter.com/appmappython)
+- [AppMap Java](https://twitter.com/appmapjava)
+
 # FAQ
 
 Visit the [AppMap FAQ](https://appland.com/docs/faq.html).

--- a/description.md
+++ b/description.md
@@ -1,0 +1,32 @@
+Interactive maps and architecture analysis help you write better Java, Python and Ruby code.
+
+# AppMap for IntelliJ IDEA, PyCharm and RubyMine
+
+Navigate your code more efficiently with interactive, accurate software architecture diagrams right in your IDE. 
+In less than two minutes you can go from installing this extension to exploring maps of your code's architecture. 
+AppMap helps you:
+
+- Onboard to code architecture, with no extra work for the team 
+- Conduct code and design reviews using live and accurate data
+- Troubleshoot hard-to-understand bugs using a "top-down" approach.
+
+Each interactive diagram links directly to the source code, and the information is easy to share.
+
+**Join us on [Discord](https://discord.com/invite/N9VUap6), [GitHub](https://github.com/applandinc/appmap-intellij-plugin) or contact us on [support@app.land](mailto:support@app.land).**
+
+## Summary of features
+
+- UML-inspired Dependency Map that displays key application components and how they are interrelated during execution 
+- Execution Trace diagrams that visualize code and data flows
+- List of Web services generated automatically from executed code
+- List of SQL queries generated automatically from executed code
+- Code linkage of the diagram to the source code
+- Filtering by class, package or function
+
+## Get started with AppMap for JetBrains IDEs
+
+Follow the instructions in the [AppMap documentation](https://appland.com/docs) and map your application in minutes.
+
+# About AppMap
+
+Visit the [AppMap documentation](https://appland.com/docs/get-started.html#what-is-appmap) to learn how AppMap works and how it accelerates development processes.

--- a/description.md
+++ b/description.md
@@ -6,24 +6,29 @@ Navigate your code more efficiently with interactive, accurate software architec
 In less than two minutes you can go from installing this extension to exploring maps of your code's architecture. 
 AppMap helps you:
 
-- Onboard to code architecture, with no extra work for the team 
-- Conduct code and design reviews using live and accurate data
-- Troubleshoot hard-to-understand bugs using a "top-down" approach.
+- [Ace your code and design reviews](https://appland.com/solutions/ace-your-code-review) using live and accurate data
+- [Onboard to code architecture](https://appland.com/docs/guides/quickly-learn-how-new-to-you-code-works.html), with no extra work for the team 
+- [Troubleshoot hard-to-understand bugs](https://appland.com/docs/guides/debug-code-using-visual-maps.html) using "top-down" and "bottom-up" approach
+- [Auto-document your design and code](https://appland.com/docs/guides/add-appmaps-to-a-code-issue.html) so you do not have to write and share it manually ever again.
 
-Each interactive diagram links directly to the source code, and the information is easy to share.
-
-**Join us on [Discord](https://discord.com/invite/N9VUap6), [GitHub](https://github.com/applandinc/appmap-intellij-plugin) or contact us on [support@app.land](mailto:support@app.land).**
+**See [dev.to/appland](https://dev.to/appland) for popular articles about AppMap use cases and tutorials.**
+Join us on [Discord](https://discord.com/invite/N9VUap6), [GitHub](https://github.com/applandinc/appmap-intellij-plugin) or contact us on [support@app.land](mailto:support@app.land).
 
 ## Summary of features
 
 - UML-inspired Dependency Map that displays key application components and how they are interrelated during execution 
-- Execution Trace diagrams that visualize code and data flows
-- List of Web services generated automatically from executed code
+- Execution Trace diagrams that visualize code and data flows:
+  - Web service endpoints
+  - Function calls
+  - SQL commands
+  - REST calls
+  - Semantic code labels
 - List of SQL queries generated automatically from executed code
+- List of Web services generated automatically from executed code
 - Code linkage of the diagram to the source code
-- Filtering by class, package or function
+- Filtering by class, package, function or label
 
-## Get started with AppMap for JetBrains IDEs
+## Get started with AppMap
 
 Follow the instructions in the [AppMap documentation](https://appland.com/docs) and map your application in minutes.
 


### PR DESCRIPTION
Initial draft of the plugin description is in description.md.
Fixes #15 