### PR TITLE
Initial implementation of AppMap tool window

### DIFF
--- a/.run/intellij-plugin [runIde].run.xml
+++ b/.run/intellij-plugin [runIde].run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="intellij-plugin [runIde]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/intellij-plugin [test].run.xml
+++ b/.run/intellij-plugin [test].run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="intellij-plugin [test]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/main/java/appland/Icons.java
+++ b/src/main/java/appland/Icons.java
@@ -5,5 +5,10 @@ import com.intellij.openapi.util.IconLoader;
 import javax.swing.*;
 
 public class Icons {
+    // 16x16
     public static final Icon APPMAP_FILE = IconLoader.getIcon("/icons/appmap.svg", Icons.class);
+
+    // 13x13
+    public static final Icon APPMAP_FILE_SMALL = IconLoader.getIcon("/icons/appmap_small.svg", Icons.class);
+    public static final Icon TOOL_WINDOW = APPMAP_FILE_SMALL;
 }

--- a/src/main/java/appland/index/AppMapMetadata.java
+++ b/src/main/java/appland/index/AppMapMetadata.java
@@ -1,0 +1,57 @@
+package appland.index;
+
+import com.intellij.util.PathUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/**
+ * Contains metadata about a single AppMap.
+ */
+public final class AppMapMetadata {
+    @NotNull
+    private final String name;
+    @NotNull
+    private final String filepath;
+
+    public AppMapMetadata(@NotNull String name, @NotNull String filepath) {
+        this.name = name;
+        this.filepath = filepath;
+    }
+
+    @NotNull
+    public String getName() {
+        return name;
+    }
+
+    @NotNull
+    public String getSystemIndependentFilepath() {
+        return filepath;
+    }
+
+    @NotNull
+    public String getFilename() {
+        return PathUtil.getFileName(filepath);
+    }
+
+    @Override
+    public String toString() {
+        return "AppMapMetadata{" +
+                "name='" + name + '\'' +
+                ", filepath='" + filepath + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AppMapMetadata that = (AppMapMetadata) o;
+        return Objects.equals(name, that.name) && Objects.equals(filepath, that.filepath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, filepath);
+    }
+}

--- a/src/main/java/appland/index/AppMapMetadataIndex.java
+++ b/src/main/java/appland/index/AppMapMetadataIndex.java
@@ -1,0 +1,147 @@
+package appland.index;
+
+import com.intellij.json.JsonFileType;
+import com.intellij.json.psi.JsonFile;
+import com.intellij.json.psi.JsonObject;
+import com.intellij.json.psi.JsonStringLiteral;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.search.ProjectScope;
+import com.intellij.util.Consumer;
+import com.intellij.util.indexing.*;
+import com.intellij.util.io.DataExternalizer;
+import com.intellij.util.io.IOUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Index for appmap.json files of a project.
+ */
+public class AppMapMetadataIndex extends SingleEntryFileBasedIndexExtension<AppMapMetadata> {
+    private static final Logger LOG = Logger.getInstance("#appmap.index");
+    private static final ID<Integer, AppMapMetadata> INDEX_ID = ID.create("appmap.titleIndex");
+    private static final FileBasedIndex.FileTypeSpecificInputFilter INPUT_FILTER = new FileBasedIndex.FileTypeSpecificInputFilter() {
+        @Override
+        public void registerFileTypesUsedForIndexing(@NotNull Consumer<? super FileType> fileTypeSink) {
+            fileTypeSink.consume(JsonFileType.INSTANCE);
+        }
+
+        @Override
+        public boolean acceptInput(@NotNull VirtualFile file) {
+            return file.getName().endsWith(".appmap.json");
+        }
+    };
+    private static final DataExternalizer<AppMapMetadata> dataExternalizer = new DataExternalizer<>() {
+        @Override
+        public void save(@NotNull DataOutput out, AppMapMetadata value) throws IOException {
+            IOUtil.writeUTF(out, value.getName());
+            IOUtil.writeUTF(out, value.getSystemIndependentFilepath());
+        }
+
+        @Override
+        public AppMapMetadata read(@NotNull DataInput in) throws IOException {
+            var name = IOUtil.readUTF(in);
+            var filepath = IOUtil.readUTF(in);
+            return new AppMapMetadata(name, filepath);
+        }
+    };
+
+    /**
+     * Retrieves all AppMaps of a project from the index.
+     *
+     * @param project The current project
+     * @return The list of AppMaps metadata objects.
+     */
+    public static @NotNull List<AppMapMetadata> findAppMaps(@NotNull Project project) {
+        if (DumbService.isDumb(project)) {
+            return Collections.emptyList();
+        }
+
+        var index = FileBasedIndex.getInstance();
+        var keys = index.getAllKeys(INDEX_ID, project);
+        if (keys.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        var scope = ProjectScope.getAllScope(project);
+        var result = new ArrayList<AppMapMetadata>(keys.size());
+        for (var key : keys) {
+            result.addAll(index.getValues(INDEX_ID, key, scope));
+        }
+        return result;
+    }
+
+    @Override
+    public @NotNull ID<Integer, AppMapMetadata> getName() {
+        return INDEX_ID;
+    }
+
+    @Override
+    public @NotNull FileBasedIndex.InputFilter getInputFilter() {
+        return INPUT_FILTER;
+    }
+
+    @Override
+    public int getVersion() {
+        return 5;
+    }
+
+    @Override
+    public @NotNull DataExternalizer<AppMapMetadata> getValueExternalizer() {
+        return dataExternalizer;
+    }
+
+    @Override
+    public @NotNull SingleEntryIndexer<AppMapMetadata> getIndexer() {
+        return new SingleEntryIndexer<>(false) {
+            @Override
+            protected @Nullable AppMapMetadata computeValue(@NotNull FileContent inputData) {
+                var inputFile = inputData.getPsiFile();
+                assert inputFile instanceof JsonFile;
+
+                var jsonFile = (JsonFile) inputFile;
+                var top = jsonFile.getTopLevelValue();
+                if (!(top instanceof JsonObject)) {
+                    LOG.debug("top property not an object");
+                    return null;
+                }
+
+                var metadata = ((JsonObject) top).findProperty("metadata");
+                if (metadata == null) {
+                    LOG.debug("metadata property not found");
+                    return null;
+                }
+
+                var metadataValue = metadata.getValue();
+                if (!(metadataValue instanceof JsonObject)) {
+                    LOG.debug("metadata property not an object");
+                    return null;
+                }
+
+                var nameProperty = ((JsonObject) metadataValue).findProperty("name");
+                if (nameProperty == null) {
+                    LOG.debug("name metadata property not found");
+                    return null;
+                }
+
+                var name = nameProperty.getValue();
+                if (!(name instanceof JsonStringLiteral)) {
+                    LOG.debug("name property is not a string");
+                    return null;
+                }
+
+                return new AppMapMetadata(((JsonStringLiteral) name).getValue(), inputData.getFile().getPath());
+            }
+        };
+    }
+}

--- a/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
+++ b/src/main/java/appland/toolwindow/AppMapToolWindowFactory.java
@@ -1,0 +1,24 @@
+package appland.toolwindow;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowFactory;
+import com.intellij.ui.content.ContentFactory;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Factory to create AppMap-mode tool windows.
+ */
+public class AppMapToolWindowFactory implements ToolWindowFactory {
+    @Override
+    public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+        var content = ContentFactory.SERVICE.getInstance().createContent(null, null, false);
+        var panel = new AppMapWindowPanel(project, content);
+        /* content.setComponent(DumbService.getInstance(project).wrapWithSpoiler(panel, () -> {
+            ApplicationManager.getApplication().invokeLater(panel::rebuild, project.getDisposed());
+        }, panel)); */
+        content.setComponent(panel);
+        toolWindow.getContentManager().addContent(content);
+    }
+}
+

--- a/src/main/java/appland/toolwindow/AppMapTreeModel.java
+++ b/src/main/java/appland/toolwindow/AppMapTreeModel.java
@@ -1,0 +1,129 @@
+package appland.toolwindow;
+
+import appland.Icons;
+import appland.index.AppMapMetadata;
+import appland.index.AppMapMetadataIndex;
+import com.intellij.ide.projectView.PresentationData;
+import com.intellij.ide.util.treeView.AbstractTreeStructure;
+import com.intellij.ide.util.treeView.NodeDescriptor;
+import com.intellij.ide.util.treeView.PresentableNodeDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.ArrayUtilRt;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Tree model used by the tree in the AppMap tool window.
+ * <p>
+ * It supports only one level in the hierarchy. The root node is hidden. Underneath all appmap files are listed.
+ */
+class AppMapTreeModel extends AbstractTreeStructure {
+    private final Object ROOT = new Object();
+    private final Project project;
+
+    public AppMapTreeModel(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public @NotNull Object getRootElement() {
+        return ROOT;
+    }
+
+    @Override
+    public boolean isToBuildChildrenInBackground(@NotNull Object element) {
+        return true;
+    }
+
+    @Override
+    public @Nullable Object getParentElement(@NotNull Object element) {
+        return element == ROOT ? null : ROOT;
+    }
+
+    @Override
+    public Object @NotNull [] getChildElements(@NotNull Object element) {
+        return element == ROOT ? AppMapMetadataIndex.findAppMaps(project).toArray() : ArrayUtilRt.EMPTY_OBJECT_ARRAY;
+    }
+
+    @Override
+    public boolean isAlwaysLeaf(@NotNull Object element) {
+        return element instanceof AppMapMetadata;
+    }
+
+    @Override
+    public @NotNull NodeDescriptor<?> createDescriptor(@NotNull Object element, @Nullable NodeDescriptor parentDescriptor) {
+        if (element == ROOT) {
+            return new AppMapRootNodeDescriptor(project, parentDescriptor);
+        }
+
+        if (element instanceof AppMapMetadata) {
+            return new SingleAppMapDescriptor(project, parentDescriptor, (AppMapMetadata) element);
+        }
+
+        throw new IllegalStateException("unexpected tree node element type: " + element);
+    }
+
+    @Override
+    public void commit() {
+    }
+
+    @Override
+    public boolean hasSomethingToCommit() {
+        return false;
+    }
+
+    static class SingleAppMapDescriptor extends PresentableNodeDescriptor<Object> {
+        private final AppMapMetadata data;
+
+        public SingleAppMapDescriptor(@NotNull Project project, @Nullable NodeDescriptor<?> parentDescriptor, @NotNull AppMapMetadata data) {
+            super(project, parentDescriptor);
+            this.data = data;
+
+            myName = data.getName();
+
+            var presentation = getTemplatePresentation();
+            presentation.setIcon(Icons.APPMAP_FILE_SMALL);
+            presentation.setPresentableText(data.getName());
+            presentation.setLocationString(data.getFilename());
+        }
+
+        @Override
+        protected boolean shouldUpdateData() {
+            return false;
+        }
+
+        @Override
+        protected void update(@NotNull PresentationData presentation) {
+        }
+
+        @Override
+        public String getName() {
+            return data.getName();
+        }
+
+        @Override
+        public Object getElement() {
+            return data;
+        }
+
+        public AppMapMetadata getAppMapData() {
+            return data;
+        }
+    }
+
+    private class AppMapRootNodeDescriptor extends NodeDescriptor<Object> {
+        public AppMapRootNodeDescriptor(@NotNull Project project, @Nullable NodeDescriptor<?> parentDescriptor) {
+            super(project, parentDescriptor);
+        }
+
+        @Override
+        public boolean update() {
+            return false;
+        }
+
+        @Override
+        public Object getElement() {
+            return ROOT;
+        }
+    }
+}

--- a/src/main/java/appland/toolwindow/AppMapWindowPanel.java
+++ b/src/main/java/appland/toolwindow/AppMapWindowPanel.java
@@ -1,0 +1,155 @@
+package appland.toolwindow;
+
+import appland.Messages;
+import appland.files.AppMapFiles;
+import com.intellij.ide.util.treeView.NodeDescriptor;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataProvider;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.SimpleToolWindowPanel;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.vfs.AsyncFileListener;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.ui.ScrollPaneFactory;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.tree.AsyncTreeModel;
+import com.intellij.ui.tree.StructureTreeModel;
+import com.intellij.ui.treeStructure.SimpleTree;
+import com.intellij.util.EditSourceOnDoubleClickHandler;
+import com.intellij.util.ui.tree.TreeUtil;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreePath;
+import java.util.Comparator;
+
+public class AppMapWindowPanel extends SimpleToolWindowPanel implements DataProvider, Disposable {
+    private static final Logger LOG = Logger.getInstance("#appmap.toolwindow");
+
+    @NotNull
+    private final SimpleTree tree;
+    private final StructureTreeModel<AppMapTreeModel> treeModel;
+    @NotNull
+    private final Project project;
+
+    public AppMapWindowPanel(@NotNull Project project, @NotNull Content parent) {
+        super(true);
+        this.project = project;
+        this.treeModel = createModel(project, this);
+        this.tree = createTree(this, treeModel);
+
+        Disposer.register(parent, this);
+        setContent(ScrollPaneFactory.createScrollPane(tree));
+
+        // refresh when dumb mode changes
+        project.getMessageBus().connect(this).subscribe(DumbService.DUMB_MODE, new DumbService.DumbModeListener() {
+            @Override
+            public void enteredDumbMode() {
+                rebuild();
+            }
+
+            @Override
+            public void exitDumbMode() {
+                rebuild();
+            }
+        });
+
+        // refresh when VirtualFiles change
+        VirtualFileManager.getInstance().addAsyncFileListener(events -> {
+            var appMapChanged = false;
+            for (var event : events) {
+                var file = event.getFile();
+                if (file != null && AppMapFiles.isAppMap(file)) {
+                    LOG.debug("appmap VirtualFile changes, rebuilding tree");
+                    appMapChanged = true;
+                    break;
+                }
+            }
+
+            return !appMapChanged ? null : new AsyncFileListener.ChangeApplier() {
+                @Override
+                public void afterVfsChange() {
+                    LOG.debug("afterVfsChange, invalidating tree");
+                    rebuild();
+                }
+            };
+        }, this);
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+    @NotNull
+    private StructureTreeModel<AppMapTreeModel> createModel(@NotNull Project project, @NotNull Disposable disposable) {
+        var model = new AppMapTreeModel(project);
+        var treeModel = new StructureTreeModel<>(model, disposable);
+        // sort alphabetically
+        treeModel.setComparator(Comparator.comparing(NodeDescriptor::toString));
+        return treeModel;
+    }
+
+    @NotNull
+    private SimpleTree createTree(@NotNull Disposable disposable, StructureTreeModel<AppMapTreeModel> treeModel) {
+        var tree = new SimpleTree(new AsyncTreeModel(treeModel, true, disposable));
+        tree.getEmptyText().setText(Messages.get("toolwindow.appmap.emptyText"));
+        tree.setRootVisible(false);
+        tree.setShowsRootHandles(false);
+
+        TreeUtil.installActions(tree);
+        new EditSourceOnDoubleClickHandler.TreeMouseListener(tree, null).installOn(tree);
+        return tree;
+    }
+
+    public void rebuild() {
+        treeModel.invalidate();
+    }
+
+    @Override
+    public @Nullable Object getData(@NotNull @NonNls String dataId) {
+        if (CommonDataKeys.NAVIGATABLE.is(dataId)) {
+            var file = getSelectedFile();
+            if (file != null) {
+                openFile(file);
+            }
+        } else if (CommonDataKeys.VIRTUAL_FILE.is(dataId)) {
+            return getSelectedFile();
+        } else if (CommonDataKeys.VIRTUAL_FILE_ARRAY.is(dataId)) {
+            var file = getSelectedFile();
+            return file == null ? VirtualFile.EMPTY_ARRAY : new VirtualFile[]{file};
+        }
+
+        return super.getData(dataId);
+    }
+
+    private @Nullable VirtualFile getSelectedFile() {
+        TreePath path = tree.getSelectionPath();
+        if (path == null) {
+            return null;
+        }
+        DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
+        Object userObject = node.getUserObject();
+        if (!(userObject instanceof AppMapTreeModel.SingleAppMapDescriptor)) {
+            return null;
+        }
+        var data = ((AppMapTreeModel.SingleAppMapDescriptor) userObject).getAppMapData();
+        var filepath = data.getSystemIndependentFilepath();
+        return LocalFileSystem.getInstance().findFileByPath(filepath);
+    }
+
+    private void openFile(@NotNull VirtualFile file) {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            FileEditorManager.getInstance(project).openFile(file, true, true);
+        }, ModalityState.defaultModalityState(), project.getDisposed());
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,6 +18,11 @@
     <fileEditorProvider implementation="appland.editor.AppMapHTMLEditorProvider"/>
     <fileIconProvider implementation="appland.editor.AppMapIconProvider"/>
 
+    <fileBasedIndex implementation="appland.index.AppMapMetadataIndex" />
+    <toolWindow id="applandToolWindow" anchor="right" secondary="false"
+                icon="appland.Icons.TOOL_WINDOW"
+                factoryClass="appland.toolwindow.AppMapToolWindowFactory"/>
+
     <errorHandler implementation="applang.GitHubErrorHandler"/>
   </extensions>
 

--- a/src/main/resources/icons/appmap_small.svg
+++ b/src/main/resources/icons/appmap_small.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="13"
+   height="13"
+   viewBox="0 0 13 13"
+   fill="none"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="appmap_small.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2061"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="99.8125"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     fill-rule="evenodd"
+     clip-rule="evenodd"
+     d="M 10.06557,8.6083127 7.0268835,2.4927063 6.5000002,1.5 5.9989207,2.4927063 1.5,11.5 H 2.6634391 L 3.2236533,10.313563 3.792471,9.1354377 5.2860233,5.9104189 6.5000002,3.5000001 9.1741854,9.1354377 9.4537479,9.7093753 10.329054,11.5 H 11.5 Z"
+     fill="#ff07aa"
+     id="path2"
+     style="stroke-width:0.640434" />
+</svg>

--- a/src/main/resources/messages/appland.properties
+++ b/src/main/resources/messages/appland.properties
@@ -1,8 +1,11 @@
 appmap.editor.name=AppMap
 
+toolwindow.stripe.applandToolWindow=AppMaps
+
 action.showRecentAppmap.text=AppMap: Open the most recently modified AppMap
 action.showRecentAppmap.description=Locate and open the most recently modified AppMap inside of your project files.
 action.showRecentAppmap.notFoundErrorTitle=No AppMap Found
 action.showRecentAppmap.notFoundErrorMessage=No AppMap file inside of your project could be found.
 
 errorReporter.actionText=Report on GitHub
+toolwindow.appmap.emptyText=No AppMaps found

--- a/src/test/java/appland/AppMapBaseTest.java
+++ b/src/test/java/appland/AppMapBaseTest.java
@@ -1,0 +1,13 @@
+package appland;
+
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AppMapBaseTest extends LightPlatformCodeInsightFixture4TestCase {
+    /**
+     * Creates a minimal version of AppMap JSON, which contains the metadata with a name.
+     */
+    public String createAppMapMetadataJSON(@NotNull String name) {
+        return String.format("{\"metadata\": { \"name\": \"%s\" }}", name);
+    }
+}

--- a/src/test/java/appland/index/AppMapMetadataIndexTest.java
+++ b/src/test/java/appland/index/AppMapMetadataIndexTest.java
@@ -1,0 +1,26 @@
+package appland.index;
+
+import appland.AppMapBaseTest;
+import org.junit.Test;
+
+import java.util.Comparator;
+
+public class AppMapMetadataIndexTest extends AppMapBaseTest {
+    @Test
+    public void index() {
+        myFixture.configureByText("a.appmap.json", createAppMapMetadataJSON("a"));
+        myFixture.configureByText("b.appmap.json", createAppMapMetadataJSON("b"));
+        myFixture.configureByText("c.appmap.json", createAppMapMetadataJSON("c"));
+
+        var appMaps = AppMapMetadataIndex.findAppMaps(getProject());
+        assertEquals(3, appMaps.size());
+        appMaps.sort(Comparator.comparing(AppMapMetadata::getName));
+
+        assertEquals(new AppMapMetadata("a", "/src/a.appmap.json"), appMaps.get(0));
+        assertEquals(new AppMapMetadata("b", "/src/b.appmap.json"), appMaps.get(1));
+        assertEquals(new AppMapMetadata("c", "/src/c.appmap.json"), appMaps.get(2));
+
+        myFixture.configureByText("d.appmap.json", createAppMapMetadataJSON("d"));
+        assertEquals(4, AppMapMetadataIndex.findAppMaps(getProject()).size());
+    }
+}


### PR DESCRIPTION
Closes #26 

- Adds an index containing the metadata of all `.appmap.json` files found in the current project
- Adds a toolwindow, which displays the list of all available AppMap files. For each item the name (i.e. `metadata/name`) and the filename is displayed
- Changes to `.appmap.json` files on disk trigger a refresh of the tree
- Double-clicking or ctrl+enter open the file in the AppMap editor (this follows IntelliJ's defaults)
- Typing when the tree is focused highlights the next matching item (as almost anywhere else in IntelliJ)

@ptrdvrk @dustinbyrne

Questions:
- The search filter is not yet implemented. My suggestion is a text input field at the top of the panel. Is that an alternative to the filter of VSCode, which is hidden in a submenu?

To do:
- [ ] The search filter
- [ ] Testing performance and UI refresh with many files
- [ ] Suppress tree updates when the panel is hidden to avoid UI freezes

Preview of the current status (due to a lack of test data the same appmap file was copied many times):
![Screenshot_003](https://user-images.githubusercontent.com/11473063/117144595-6712c780-adb2-11eb-89dd-01a2df5b2e25.png)
