### PR TITLE
Docs description update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AppMap Plugin Changelog
 
+## [0.2.2]
+### Changed
+- Documentation update
+
 ## [0.2.1]
 ### Changed
 - Documentation update

--- a/description.md
+++ b/description.md
@@ -1,19 +1,19 @@
-Interactive maps and architecture analysis help you write better Java, Python and Ruby code.
-
-# AppMap for JetBrains IDEs
+Interactive maps and architecture analysis help you write better Java, Python and Ruby code. Additional languages are coming soon.
 
 Navigate your code more efficiently with interactive, accurate software architecture diagrams right in your IDE. 
-In less than two minutes you can go from installing this extension to exploring maps of your code's architecture. 
+In [two minutes](https://www.loom.com/share/2634caf3a57842aea07b83be2bd9bc8d) you can go from installing this plugin to exploring maps of your code's architecture. 
 
-## Get started with AppMap
+Visit [dev.to/appland](https://dev.to/appland) for popular articles about AppMap use cases and tutorials.
 
-Follow the instructions in the [AppMap documentation](https://appland.com/docs) and map your application in minutes.
 
-**See [dev.to/appland](https://dev.to/appland) for popular articles about AppMap use cases and tutorials.**
+## Quickstart
+Follow the instructions in the **[AppMap quickstart](https://appland.com/docs/quickstart)** guide.
+
 Join us on [Discord](https://discord.com/invite/N9VUap6), [GitHub](https://github.com/applandinc/appmap-intellij-plugin) or contact us on [support@app.land](mailto:support@app.land).
 
-## Summary of features
 
+## Summary of features
+- Interactive Code Analyzer that records and processes dynamic execution traces of running code
 - Dependency Map that displays key application components and how they are interrelated during execution 
 - Execution Trace diagrams that visualize code and data flows:
   - Web service endpoints
@@ -23,24 +23,19 @@ Join us on [Discord](https://discord.com/invite/N9VUap6), [GitHub](https://githu
   - Semantic code labels
 - List of SQL queries generated automatically from executed code
 - List of Web services generated automatically from executed code
-- Code linkage of the diagram to the source code
+- Direct navigation from diagrams to sources
 - Filtering by class, package, function or label
 
-# About AppMap
 
-AppMap helps you:
+## About AppMap
+See [AppMap overview](https://appland.com/docs/get-started.html) to learn how AppMap works and how it accelerates development processes.
 
-- [Onboard to code architecture](https://appland.com/docs/guides/quickly-learn-how-new-to-you-code-works.html), with no extra work for the team 
-- [Troubleshoot hard-to-understand bugs](https://appland.com/docs/guides/debug-code-using-visual-maps.html) using "top-down" and "bottom-up" approach
-- [Auto-document your design and code](https://appland.com/docs/guides/add-appmaps-to-a-code-issue.html) so you do not have to write and share it manually ever again.
 
-Visit the [AppMap documentation](https://appland.com/docs/get-started.html#what-is-appmap) and [AppLand blog](https://dev.to/appland) to learn how AppMap works and how it accelerates development processes.
-
-**Twitter**
+## Twitter
 - [AppMap Ruby](https://twitter.com/appmapruby)
 - [AppMap Python](https://twitter.com/appmappython)
 - [AppMap Java](https://twitter.com/appmapjava)
 
-# FAQ
 
+## FAQ
 Visit the [AppMap FAQ](https://appland.com/docs/faq.html).

--- a/description.md
+++ b/description.md
@@ -7,7 +7,7 @@ Visit [dev.to/appland](https://dev.to/appland) for popular articles about AppMap
 
 
 ## Quickstart
-Follow the instructions in the **[AppMap quickstart](https://appland.com/docs/quickstart)** guide.
+Follow the instructions in the **[AppMap quickstart](https://appland.com/docs/quickstart/)** guide.
 
 
 ## Summary of features

--- a/description.md
+++ b/description.md
@@ -1,7 +1,7 @@
 Interactive maps and architecture analysis help you write better Java, Python and Ruby code. Additional languages are coming soon.
 
 Navigate your code more efficiently with interactive, accurate software architecture diagrams right in your IDE. 
-In [two minutes](https://www.loom.com/share/2634caf3a57842aea07b83be2bd9bc8d) you can go from installing this plugin to exploring maps of your code's architecture. 
+In two minutes you can go from installing this plugin to exploring maps of your code's architecture. 
 
 Visit [dev.to/appland](https://dev.to/appland) for popular articles about AppMap use cases and tutorials.
 

--- a/description.md
+++ b/description.md
@@ -27,6 +27,10 @@ Join us on [Discord](https://discord.com/invite/N9VUap6), [GitHub](https://githu
 - Filtering by class, package, function or label
 
 
+## Documentation
+Go to [Reference documentation](https://appland.com/docs/reference/).
+
+
 ## About AppMap
 See [AppMap overview](https://appland.com/docs/get-started.html) to learn how AppMap works and how it accelerates development processes.
 

--- a/description.md
+++ b/description.md
@@ -9,8 +9,6 @@ Visit [dev.to/appland](https://dev.to/appland) for popular articles about AppMap
 ## Quickstart
 Follow the instructions in the **[AppMap quickstart](https://appland.com/docs/quickstart)** guide.
 
-Join us on [Discord](https://discord.com/invite/N9VUap6), [GitHub](https://github.com/applandinc/appmap-intellij-plugin) or contact us on [support@app.land](mailto:support@app.land).
-
 
 ## Summary of features
 - Interactive Code Analyzer that records and processes dynamic execution traces of running code
@@ -27,8 +25,11 @@ Join us on [Discord](https://discord.com/invite/N9VUap6), [GitHub](https://githu
 - Filtering by class, package, function or label
 
 
-## Documentation
-Go to [Reference documentation](https://appland.com/docs/reference/).
+## Resources
+- [Reference documentation](https://appland.com/docs/reference/)
+- [AppMap FAQ](https://appland.com/docs/faq.html)
+- Join us on [Discord](https://discord.com/invite/N9VUap6) and [GitHub](https://github.com/applandinc/appmap-intellij-plugin)
+- Support email: [support@app.land](mailto:support@app.land)
 
 
 ## About AppMap
@@ -39,7 +40,3 @@ See [AppMap overview](https://appland.com/docs/get-started.html) to learn how Ap
 - [AppMap Ruby](https://twitter.com/appmapruby)
 - [AppMap Python](https://twitter.com/appmappython)
 - [AppMap Java](https://twitter.com/appmapjava)
-
-
-## FAQ
-Visit the [AppMap FAQ](https://appland.com/docs/faq.html).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=0.2.1
+pluginVersion=0.2.2
 
 ideVersion=2021.1
 sinceBuild=211.0


### PR DESCRIPTION
Updated documentation page now points to https://appland.com/docs/quickstart/ for quickstart.
Bumping version to 0.2.2.