### PR TITLE
Add new action to open the AppMap documentation

### DIFF
--- a/src/main/java/appland/Icons.java
+++ b/src/main/java/appland/Icons.java
@@ -7,6 +7,7 @@ import javax.swing.*;
 public class Icons {
     // 16x16
     public static final Icon APPMAP_FILE = IconLoader.getIcon("/icons/appmap.svg", Icons.class);
+    public static final Icon APPMAP_DOCS = APPMAP_FILE;
 
     // 13x13
     public static final Icon APPMAP_FILE_SMALL = IconLoader.getIcon("/icons/appmap_small.svg", Icons.class);

--- a/src/main/java/appland/actions/AppMapDocumentationAction.java
+++ b/src/main/java/appland/actions/AppMapDocumentationAction.java
@@ -1,0 +1,21 @@
+package appland.actions;
+
+import appland.Icons;
+import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class AppMapDocumentationAction extends AnAction implements DumbAware {
+    public AppMapDocumentationAction() {
+        super(Icons.APPMAP_DOCS);
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        BrowserUtil.browse("https://appland.com/docs");
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,5 +29,8 @@
 
   <actions>
     <action id="showRecentAppmap" class="appland.actions.OpenRecentAppMapAction"/>
+    <action id="appmapDocs" class="appland.actions.AppMapDocumentationAction">
+      <add-to-group group-id="HelpMenu" anchor="before" relative-to-action="CheckForUpdate"/>
+    </action>
   </actions>
 </idea-plugin>

--- a/src/main/resources/messages/appland.properties
+++ b/src/main/resources/messages/appland.properties
@@ -5,6 +5,8 @@ action.showRecentAppmap.description=Locate and open the most recently modified A
 action.showRecentAppmap.notFoundErrorTitle=No AppMap Found
 action.showRecentAppmap.notFoundErrorMessage=No AppMap file inside of your project could be found.
 
+action.appmapDocs.text=AppMap Documentation
+
 errorReporter.actionText=Report on GitHub
 
 toolwindow.stripe.applandToolWindow=AppMaps


### PR DESCRIPTION
Closes #32 

@ptrdvrk Unfortunately the "Register" action is a bit difficult - it has different IDs in IntelliJ Ultimate and Community and it's not always available in Community IDEs. I declared it to be shown "Before action "Check Updates"", which should be fine for most.

Would you like an icon with the new menu item or not?
<img width="429" alt="Screen Shot 2021-05-25 at 17 07 51" src="https://user-images.githubusercontent.com/11473063/119522772-88951c80-bd7c-11eb-9515-69eefdfe94fd.png">
<img width="286" alt="Screen Shot 2021-05-25 at 17 10 16" src="https://user-images.githubusercontent.com/11473063/119522779-8a5ee000-bd7c-11eb-9416-e187a4a6c711.png">
