### PR TITLE
Fix compilation with 2021.2 rc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ buildscript {
 
 plugins {
     idea
-    id("org.jetbrains.intellij") version "1.0"
+    id("org.jetbrains.intellij") version "1.1.4"
     id("org.jetbrains.changelog") version "1.1.2"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ pluginVersion=0.4.1
 sinceBuild=211.0
 untilBuild=212.*
 
-ideVersion=2021.1.1
-ideVersionVerifier=2021.1.1,IC-212.3116.43
+ideVersion=2021.1.3
+#ideVersionVerifier=2021.1.3,IC-212.4746.52
 
 # alternative versions to simplify development and testing
-# ideVersion=IC-212.3116.43-EAP-SNAPSHOT
+# ideVersion=IC-212.4746.52-EAP-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ sinceBuild=211.0
 untilBuild=212.*
 
 ideVersion=2021.1.3
-#ideVersionVerifier=2021.1.3,IC-212.4746.52
+ideVersionVerifier=2021.1.3,IC-212.4746.52
 
 # alternative versions to simplify development and testing
 # ideVersion=IC-212.4746.52-EAP-SNAPSHOT

--- a/src/main/java/appland/notifications/AppMapNotifications.java
+++ b/src/main/java/appland/notifications/AppMapNotifications.java
@@ -1,6 +1,5 @@
 package appland.notifications;
 
-import appland.AppMapBundle;
 import appland.AppMapPlugin;
 import appland.actions.StopAppMapRecordingAction;
 import com.intellij.ide.BrowserUtil;
@@ -14,6 +13,8 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.swing.*;
+
 import static appland.AppMapBundle.lazy;
 
 public final class AppMapNotifications {
@@ -26,7 +27,8 @@ public final class AppMapNotifications {
                                                          boolean withClose) {
 
         ApplicationManager.getApplication().invokeLater(() -> {
-            var notification = new Notification(REMOTE_RECORDING_ID, null, type);
+            // cast to Icon to avoid an ambiguity with 2021.2
+            var notification = new Notification(REMOTE_RECORDING_ID, (Icon) null, type);
             if (title != null) {
                 notification.setTitle(title);
             }


### PR DESCRIPTION
- Fix compilation with latest rc build. This only affect source-compatibility, but not not binary compatibility. As far as I can tell version 0.4.1 is working fine with 2021.2 rc.
- Update to latest gradle-intellij plugin