### PR TITLE
Index .appmap.json files of all sizes

### DIFF
--- a/src/main/java/appland/index/AppMapMetadataIndex.java
+++ b/src/main/java/appland/index/AppMapMetadataIndex.java
@@ -109,7 +109,7 @@ public class AppMapMetadataIndex extends SingleEntryFileBasedIndexExtension<AppM
 
     @Override
     public int getVersion() {
-        return 7;
+        return 8;
     }
 
     @Override

--- a/src/main/java/appland/index/AppMapMetadataIndex.java
+++ b/src/main/java/appland/index/AppMapMetadataIndex.java
@@ -20,6 +20,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,6 +30,7 @@ import java.util.List;
 public class AppMapMetadataIndex extends SingleEntryFileBasedIndexExtension<AppMapMetadata> {
     private static final Logger LOG = Logger.getInstance("#appmap.index");
     private static final ID<Integer, AppMapMetadata> INDEX_ID = ID.create("appmap.titleIndex");
+
     private static final FileBasedIndex.FileTypeSpecificInputFilter INPUT_FILTER = new FileBasedIndex.FileTypeSpecificInputFilter() {
         @Override
         public void registerFileTypesUsedForIndexing(@NotNull Consumer<? super FileType> fileTypeSink) {
@@ -85,6 +87,14 @@ public class AppMapMetadataIndex extends SingleEntryFileBasedIndexExtension<AppM
             }, scope);
         }
         return result;
+    }
+
+    /**
+     * Enforce indexing of files of all sizes.
+     */
+    @Override
+    public @NotNull Collection<FileType> getFileTypesWithSizeLimitNotApplicable() {
+        return Collections.singletonList(JsonFileType.INSTANCE);
     }
 
     @Override


### PR DESCRIPTION
Previously, files larger than IntelliJ's limit for code insight were not indexed and thus unavailable in the list of AppMaps.