### PR TITLE
Display an error message to the user if the file is too large to be loaded

### DIFF
--- a/src/main/resources/messages/appland.properties
+++ b/src/main/resources/messages/appland.properties
@@ -84,3 +84,6 @@ userMilestones.welcomeTitle=Quickstart: Welcome
 userMilestones.installAgentTitle=Quickstart: Install AppMap Agent
 userMilestones.recordAppMapsTitle=Quickstart: Record AppMaps
 userMilestones.appMapsTableTitle=Quickstart: Open AppMaps
+
+editor.fileTooLarge.error=The file is too large to be displayed.
+editor.fileTooLarge.details=Files up to {0} megabytes are supported.


### PR DESCRIPTION
Closes #70 
This PR adds the needed changes to display an error message for too large files instead of trying to load the content.
The file size limit is user-configurable as a global, application-wide value within the IDE and defaults to 20 megabytes. Only advanced users of the IDE would customize this.

Although it's technically possible to load the complete content instead of the truncated content, this isn't working well with the current implementation.
Currently, the file content is turned into a JS method call string taking the complete content as argument. For large files this (and the needed JSON escaping of the content) makes things memory hungry and slow.
A method call is needed because the JS application is living in a sandboxed environment, which doesn't have access to `file://` URLs.



Possible workaround, which needs more investigation and more time than this PR: 
Add a custom scheme or resource URL handler and then instruct the JS application to load a file with our own custom protocol. The initial investigation of this turned out to be difficult, because custom scheme handlers must be added to the global JBCEF application before creating the first client. This isn't entirely under own control.
Additionally, we'd have to be very careful to not allow file system access for non-appmap files residing on the local filesystem.

![Screenshot_20220117_122835](https://user-images.githubusercontent.com/11473063/149762730-a2cdee4c-10b8-4fb8-8ab7-7bacf965160a.png)

