### PR TITLE
Support 2022.1 EAP releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # AppMap Plugin Changelog
 
-## [Unreleased]
+## [0.7.6]
 ### Added
 - Support 2022.1 EAP
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AppMap Plugin Changelog
 
+## [Unreleased]
+### Added
+- Support 2022.1 EAP
+
 ## [0.7.5]
 ### Changed
 - Express.js is now a supported web framework 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AppLand for JetBrains IDEs
 
 ## System Requirements
-**IntelliJ IDEA 2021.1** is required to use this plugin.
+**IntelliJ IDEA 2021.1 or later** is required to use this plugin.
 
 Only installations, which use the bundled JetBrains Java runtime, support the JCEF engine for rendering.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ buildscript {
 
 plugins {
     idea
-    id("org.jetbrains.intellij") version "1.1.4"
+    id("org.jetbrains.intellij") version "1.3.1"
     id("org.jetbrains.changelog") version "1.1.2"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=0.7.5
+pluginVersion=0.7.6
 
 sinceBuild=211.0
 untilBuild=221.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,12 @@
 pluginVersion=0.7.5
 
 sinceBuild=211.0
-untilBuild=213.*
+untilBuild=221.*
 
 ideVersion=2021.1.3
-ideVersionVerifier=2021.1.3,IC-2021.2.3,IC-2021.3
+ideVersionVerifier=IC-2021.1.3,IC-2021.2.3,IC-2021.3,IC-221.3427.89
 
 # alternative versions to simplify development and testing
 # ideVersion=IC-2021.2.3
-# ideVersion=IC-213.5744.125-EAP-SNAPSHOT
+# ideVersion=IC-2021.3.2
+# ideVersion=IC-221.3427.89-EAP-SNAPSHOT


### PR DESCRIPTION
Closes https://github.com/applandinc/appmap-intellij-plugin/issues/72
This PR updates the build setup to support 2022.1 and to run the plugin verifier against the current EAP of 2022.1.