### PR TITLE
Support 2022.2 EAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AppMap Plugin Changelog
 
+## [Unreleased]
+### Updated
+- Compatibility with 2022.2 EAP
+
 ## [0.7.9]
 - Update community links within the extension description
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ buildscript {
 
 plugins {
     idea
-    id("org.jetbrains.intellij") version "1.3.1"
+    id("org.jetbrains.intellij") version "1.5.2"
     id("org.jetbrains.changelog") version "1.1.2"
 }
 
@@ -56,6 +56,8 @@ tasks {
     buildSearchableOptions.get().enabled = false
 
     buildPlugin {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
         copyPluginAssets("")
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,13 @@
 pluginVersion=0.7.9
 
 sinceBuild=211.0
-untilBuild=221.*
+untilBuild=222.*
 
 ideVersion=2021.1.3
-ideVersionVerifier=IC-2021.1.3,IC-2021.2.3,IC-2021.3,IC-221.3427.89
+ideVersionVerifier=IC-2021.1.3,IC-2021.2.3,IC-2021.3,IC-2022.1.3
 
 # alternative versions to simplify development and testing
-# ideVersion=IC-2021.2.3
-# ideVersion=IC-2021.3.2
-# ideVersion=IC-221.3427.89-EAP-SNAPSHOT
+#ideVersion=IC-2021.2.3
+#ideVersion=IC-2021.3.2
+#ideVersion=IC-2022.1.3
+#ideVersion=IC-222.3345.16-EAP-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/appland/actions/OpenAppMapsAction.java
+++ b/src/main/java/appland/actions/OpenAppMapsAction.java
@@ -10,6 +10,11 @@ import java.util.Objects;
 
 public class OpenAppMapsAction extends AnAction {
     @Override
+    public void update(@NotNull AnActionEvent e) {
+        e.getPresentation().setEnabled(UserMilestonesEditorProvider.isSupported());
+    }
+
+    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         UserMilestonesEditorProvider.open(Objects.requireNonNull(e.getProject()), MilestonesViewType.AppMapsTable);
     }

--- a/src/main/java/appland/actions/OpenQuickstartAction.java
+++ b/src/main/java/appland/actions/OpenQuickstartAction.java
@@ -10,6 +10,11 @@ import java.util.Objects;
 
 public class OpenQuickstartAction extends AnAction {
     @Override
+    public void update(@NotNull AnActionEvent e) {
+        e.getPresentation().setEnabled(UserMilestonesEditorProvider.isSupported());
+    }
+
+    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         UserMilestonesEditorProvider.open(Objects.requireNonNull(e.getProject()), MilestonesViewType.InstallAgent);
     }

--- a/src/main/java/appland/milestones/UserMilestonesEditorProvider.java
+++ b/src/main/java/appland/milestones/UserMilestonesEditorProvider.java
@@ -22,9 +22,13 @@ public class UserMilestonesEditorProvider implements FileEditorProvider, DumbAwa
         FileEditorManager.getInstance(project).openFile(dummyFile, true);
     }
 
+    public static boolean isSupported() {
+        return JBCefApp.isSupported();
+    }
+
     @NotNull
     public static Boolean isQuickstartFile(@NotNull VirtualFile file) {
-        return MILESTONE_TYPE_KEY.isIn(file);
+        return isSupported() && MILESTONE_TYPE_KEY.isIn(file);
     }
 
     @Override

--- a/src/main/java/appland/toolwindow/milestones/UserMilestonesPanel.java
+++ b/src/main/java/appland/toolwindow/milestones/UserMilestonesPanel.java
@@ -1,6 +1,7 @@
 package appland.toolwindow.milestones;
 
 import appland.milestones.MilestonesViewType;
+import appland.milestones.UserMilestonesEditorProvider;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.components.panels.VerticalLayout;
 import org.jetbrains.annotations.NotNull;
@@ -16,14 +17,16 @@ public class UserMilestonesPanel extends JPanel {
     public UserMilestonesPanel(@NotNull Project project) {
         super(new VerticalLayout(5));
 
-        addPanel("Quickstart", new UserMilestoneContentPanel() {
-            @Override
-            protected void setupPanel() {
-                add(new StatusLabel(UserMilestoneStatus.Incomplete, "Install AppMap agent", () -> open(project, MilestonesViewType.InstallAgent)));
-                add(new StatusLabel(UserMilestoneStatus.Incomplete, "Record AppMaps", () -> open(project, MilestonesViewType.RecordAppMaps)));
-                add(new StatusLabel(UserMilestoneStatus.Incomplete, "Open AppMaps", () -> open(project, MilestonesViewType.AppMapsTable)));
-            }
-        });
+        if (UserMilestonesEditorProvider.isSupported()) {
+            addPanel("Quickstart", new UserMilestoneContentPanel() {
+                @Override
+                protected void setupPanel() {
+                    add(new StatusLabel(UserMilestoneStatus.Incomplete, "Install AppMap agent", () -> open(project, MilestonesViewType.InstallAgent)));
+                    add(new StatusLabel(UserMilestoneStatus.Incomplete, "Record AppMaps", () -> open(project, MilestonesViewType.RecordAppMaps)));
+                    add(new StatusLabel(UserMilestoneStatus.Incomplete, "Open AppMaps", () -> open(project, MilestonesViewType.AppMapsTable)));
+                }
+            });
+        }
 
         addPanel("Documentation", new UserMilestoneContentPanel() {
             @Override


### PR DESCRIPTION
The next major version of JetBrains IDEs is now in beta (2022.2).

This PR 
- updates the Gradle wrapper
- adds compatibility for 2022.2
- hides the user milestones links and webview if unsupported. This happened in the sandboxed IDE of 2022.2 beta