### PR TITLE
Drop support for older versions of IDEs, fix init of JCEF panel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,14 @@
 pluginVersion=0.7.10
 
-sinceBuild=211.0
+sinceBuild=213.0
 untilBuild=222.*
 
-ideVersion=2021.1.3
-ideVersionVerifier=IC-2021.1.3,IC-2021.2.3,IC-2021.3,IC-2022.1.3
+ideVersion=2021.3.3
+ideVersionVerifier=IC-2021.3,IC-2022.1.3
 
 lombokVersion=1.18.24
 
 # alternative versions to simplify development and testing
-#ideVersion=IC-2021.2.3
 #ideVersion=IC-2021.3.2
 #ideVersion=IC-2022.1.3
 #ideVersion=IC-222.3345.16-EAP-SNAPSHOT

--- a/src/main/java/appland/editor/AppMapFileEditor.java
+++ b/src/main/java/appland/editor/AppMapFileEditor.java
@@ -65,8 +65,7 @@ public class AppMapFileEditor extends UserDataHolderBase implements FileEditor {
     private final Project project;
     private final String baseURL;
     private final VirtualFile file;
-    private final JBCefClient jcefClient = JBCefApp.getInstance().createClient();
-    private final JCEFHtmlPanel contentPanel = new JCEFHtmlPanel(jcefClient, null);
+    private final JCEFHtmlPanel contentPanel = new JCEFHtmlPanel(true, null, null);
     private final JBCefJSQuery viewSourceBridge = JBCefJSQuery.create((JBCefBrowserBase) contentPanel);
     private final JBCefJSQuery uploadAppMapBridge = JBCefJSQuery.create((JBCefBrowserBase) contentPanel);
     private final MultiPanel multiPanel = new MultiPanel() {
@@ -108,9 +107,8 @@ public class AppMapFileEditor extends UserDataHolderBase implements FileEditor {
         this.file = file;
         this.baseURL = getBaseURL();
 
-        Disposer.register(this, jcefClient);
-        Disposer.register(this, contentPanel);
-        Disposer.register(this, viewSourceBridge);
+        // contentPanel and jcefBridge register with the client as Disposable parent
+        Disposer.register(this, contentPanel.getJBCefClient());
 
         setupVfsListener(file);
 


### PR DESCRIPTION
The install guide feature needs a newer SDK, because the problems view tab is not extendable in older versions.
This PR drops support for 2021.1 and 2021.2 and updates init of our web view panel to use the API, which is now available with the updated SDK.