### PR TITLE
Sort selected AppMaps in the same way as the VSCode plugin

### DIFF
--- a/src/main/java/appland/index/AppMapMetadata.java
+++ b/src/main/java/appland/index/AppMapMetadata.java
@@ -57,9 +57,7 @@ public final class AppMapMetadata {
     }
 
     public int getSortCount() {
-        return requestCount + (requestCount > 0 ? 1_000_000 : 0)
-                + queryCount + (queryCount > 0 ? 1_000_000 : 0)
-                + functionsCount + (functionsCount > 0 ? 1_000_000 : 0);
+        return requestCount * 100 + queryCount * 100 + functionsCount * 100;
     }
 
     public int getFunctionsCount() {


### PR DESCRIPTION
The AppMaps shown in the install guide web view were not sorted in the same way as the VSCode plugin.