### PR TITLE
Disable update check of the IntelliJ Gradle plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,8 @@ ideVersion=IC-2021.3.3
 #ideVersion=IC-2022.3
 #ideVersion=IC-231.8109.90-EAP-SNAPSHOT
 
+# https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-build-features.html#selfupdatecheck
+org.jetbrains.intellij.buildFeature.selfUpdateCheck=false
+
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 org.gradle.parallel=false


### PR DESCRIPTION
Disable the build-time messages about available updates of the intellij-gradle plugin. This is purely to improve the development experience, because it's less cluttering the build output.