### PR TITLE
 Use latest stable version of org.jetbrains.intellij.platform

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ buildscript {
 plugins {
     idea
     id("org.jetbrains.kotlin.jvm")
-    id("org.jetbrains.intellij.platform") version "2.6.1-SNAPSHOT"
+    id("org.jetbrains.intellij.platform") version "2.7.0"
     id("org.jetbrains.changelog") version "2.2.1"
     id("com.adarshr.test-logger") version "3.2.0"
     id("de.undercouch.download") version "5.6.0"


### PR DESCRIPTION
- Use latest stable version of org.jetbrains.intellij.platform. The stable version has been released a few days ago.