### PR TITLE
Minor code cleanup

### DIFF
--- a/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
+++ b/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
@@ -210,7 +210,7 @@ public class DefaultAppLandJsonRpcService implements AppLandJsonRpcService, AppL
             } catch (ExecutionException e) {
                 LOG.debug("Failed to launch AppMap JSON-RPC server, command: " + commandLine.getCommandLineString(), e);
             } finally {
-                if (!isDisposed) {
+                if (!isDisposed && !project.isDisposed()) {
                     project.getMessageBus().syncPublisher(AppLandJsonRpcListener.TOPIC).serverStarted();
                 }
             }
@@ -339,7 +339,7 @@ public class DefaultAppLandJsonRpcService implements AppLandJsonRpcService, AppL
                 }
             }
         } finally {
-            if (!isDisposed) {
+            if (!isDisposed && !project.isDisposed()) {
                 project.getMessageBus().syncPublisher(AppLandJsonRpcListener.TOPIC).serverStopped();
             }
         }
@@ -573,7 +573,7 @@ public class DefaultAppLandJsonRpcService implements AppLandJsonRpcService, AppL
             if (restartNeeded) {
                 nextRestartDelayMillis = (long) ((double) currentRestartDelay * NEXT_RESTART_FACTOR);
                 AppExecutorUtil.getAppScheduledExecutorService().schedule(() -> {
-                            if (!isDisposed) {
+                            if (!isDisposed && !project.isDisposed()) {
                                 try {
                                     DefaultAppLandJsonRpcService.this.startServer();
                                 } finally {

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
@@ -24,6 +24,11 @@ public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
     @Rule
     public OverrideIdeHttpProxyRule ideHttpProxyRule = new OverrideIdeHttpProxyRule(mockServerRule);
 
+    @Override
+    protected boolean runInDispatchThread() {
+        return false;
+    }
+
     @Test
     public void downloadWithHttpProxy() throws Exception {
         var toolType = CliTool.AppMap;

--- a/plugin-core/src/test/java/appland/files/AppMapFilesTest.java
+++ b/plugin-core/src/test/java/appland/files/AppMapFilesTest.java
@@ -22,6 +22,11 @@ public class AppMapFilesTest extends LightPlatformCodeInsightFixture4TestCase {
         return new TempDirTestFixtureImpl();
     }
 
+    @Override
+    protected boolean runInDispatchThread() {
+        return false;
+    }
+
     @Test
     public void files() {
         var file = myFixture.configureByText("a.json", "");


### PR DESCRIPTION
- Don't send on the messagebus if the project is already disposed. This fixes a few logged errors of CI
- Run tests using commandlines outside the dispatch thread.