### PR TITLE
Support CLI binaries  bundled with the plugin package

### DIFF
--- a/.run/runIde w_ deployment settings.run.xml
+++ b/.run/runIde w_ deployment settings.run.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="runIde w/ deployment settings" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runIdeWithDeploymentSettings" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -4,3 +4,82 @@
 # AppMap for JetBrains IDEs
 
 Please see [./description.md](./description.md) for a detailed description of the AppMap plugin for JetBrains IDEs.
+
+## Deployment
+
+By default, the plugin ZIP file only bundles the JAR file of the AppMap Java agent.
+
+It's possible to customize settings and/or to bundle AppMap binaries into the plugin ZIP afterward to simplify the
+deployment.
+
+### Customizing Deployment
+
+By modifying the plugin ZIP archive, the deployment can be customized.
+
+The current status of the deployment is shown with action `Tools > AppMap > Plugin Status Report`.
+
+Settings can be customized by adding a `site-config.json` file at `./intellij-appmap/site-config.json` inside the ZIP file.
+
+The file must be a valid JSON file.
+It allows configuring telemetry and auto-update of AppMap binaries.
+By default, no custom telemetry is configured and auto-update is enabled.
+
+Default settings:
+
+```json
+{
+    "appMap.telemetry": null,
+    "appMap.autoUpdateTools": true
+}
+```
+
+#### Splunk Telemetry
+
+For telemetry deployment, only `splunk` is supported as backend.
+If Splunk is configured, then the user-setting to turn off telemetry is ignored.
+
+```json
+{
+    "appMap.telemetry": {
+        "backend": "splunk",
+        "url": "https://splunk.example.com",
+        "token": "my-hec-token",
+        "ca": "optional-ca-certificate"
+    },
+    "appMap.autoUpdateTools": true
+}
+```
+
+### Bundling AppMap binaries
+
+The following directory inside the plugin ZIP file is searched for AppMap binaries:
+
+- `./intellij-appmap/resources/`
+
+A bundled binary must follow this pattern to be found: `{type}-{os}-{arch}-v{version}`.
+OS-specific file extensions like `.exe` must be appended.
+
+If more than one compatible, bundled binary is found, then the binary with the latest version is preferred.
+
+If a downloaded binary has a higher version than the bundled binary, then the downloaded binary is used.
+If a downloaded binary and the best-matching bundled binary have the same version, then the bundled binary is used.
+
+Possible values:
+
+- `type`:
+    - `appmap`
+    - `scanner`
+- `os`:
+    - `win`
+    - `macos`
+    - `linux`
+- `arch`:
+    - `x64`
+    - `arm64`
+- `version`: a version in the SemVer format, e.g. `1.2.3`.
+
+Examples:
+
+- `./intellij-appmap/resources/appmap-win-x64-v3.9.1.exe`
+- `./intellij-appmap/resources/appmap-macos-arm64-v3.9.1.exe`
+- `./intellij-appmap/resources/appmap-linux-arm64-v3.9.1.exe`

--- a/development.md
+++ b/development.md
@@ -27,3 +27,8 @@ Values `appmap_dir` of these files are marked to be indexed even when such direc
 Content roots are usually the top-level directories of a project.
 Therefore, `appmap.yml` files located in a nested, excluded folder won't be found by this implementation.
 We're not collecting such files because iterating the complete directory tree is expensive without an index.
+
+### Deployment Settings
+
+To launch with automatically created deployment settings for testing, use
+`./gradlew runIdeWithDeploymentSettings`.

--- a/plugin-core/src/main/java/appland/AppMapPlugin.java
+++ b/plugin-core/src/main/java/appland/AppMapPlugin.java
@@ -33,6 +33,6 @@ public final class AppMapPlugin {
     }
 
     public static @NotNull Path getAppMapJavaAgentPath() {
-        return getPluginPath().resolve("appmap-java-agent").resolve("appmap-agent.jar");
+        return getPluginPath().resolve("resources").resolve("appmap-agent.jar");
     }
 }

--- a/plugin-core/src/main/java/appland/cli/AppLandDownloadListener.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandDownloadListener.java
@@ -10,5 +10,5 @@ public interface AppLandDownloadListener {
     @Topic.AppLevel
     Topic<AppLandDownloadListener> TOPIC = Topic.create("appland.cliDownload", AppLandDownloadListener.class);
 
-    void downloadFinished(@NotNull CliTool type, boolean success);
+    void downloadFinished(@NotNull CliTool type, @NotNull AppMapDownloadStatus status);
 }

--- a/plugin-core/src/main/java/appland/cli/AppLandDownloadService.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandDownloadService.java
@@ -19,25 +19,13 @@ public interface AppLandDownloadService {
     }
 
     /**
-     * @param type The type of CLI tool
+     * @param type     The type of CLI tool
+     * @param platform The platform to search for
+     * @param arch     The architecture to search for
      * @return The location on disk, where the binary for the given tool type is stored.
      * It's possible that the file does not exist yet.
      */
-    @Nullable Path getDownloadFilePath(@NotNull CliTool type);
-
-    /**
-     * @param type Type of commandline tool
-     * @return {@code true} if there's a downloaded binary of the given tool with any version
-     */
-    boolean isDownloaded(@NotNull CliTool type);
-
-    /**
-     * @param type         Type of commandline tool
-     * @param version      The required version, e.g. 1.2.3
-     * @param unitTestMode To determine the target download location
-     * @return {@code true} if there's a downloaded binary matching type and version
-     */
-    boolean isDownloaded(@NotNull CliTool type, @NotNull String version, boolean unitTestMode);
+    @Nullable Path getDownloadFilePath(@NotNull CliTool type, @NotNull String platform, @NotNull String arch);
 
     /**
      * Download a new copy of the tool binary and store it at the expected location on disk.
@@ -46,10 +34,12 @@ public interface AppLandDownloadService {
      * @param type              Type of commandline tool
      * @param version           Version to download
      * @param progressIndicator Indicator to show the download progress
-     * @return {@code true} if the download succeeded
+     * @return A {@link AppMapDownloadStatus} value indicating the result of the download.
      */
     @RequiresBackgroundThread
-    boolean download(@NotNull CliTool type, @NotNull String version, @NotNull ProgressIndicator progressIndicator);
+    @NotNull AppMapDownloadStatus download(@NotNull CliTool type,
+                                           @NotNull String version,
+                                           @NotNull ProgressIndicator progressIndicator);
 
     /**
      * Fetch metadata about the latest available version
@@ -66,10 +56,10 @@ public interface AppLandDownloadService {
     void queueDownloadTasks(@NotNull Project project) throws IOException;
 
     /**
-     * Fetch metadata about the downloaded version
+     * Fetch the latest version that has been downloaded.
      *
      * @param type Type of command line tool
-     * @return Available version or {@code null} if the retrieval was unsuccessful
+     * @return Latest available version or {@code null} if the retrieval was unsuccessful
      */
-   @Nullable String findLatestDownloadedVersion(@NotNull CliTool type);
+    @Nullable String findLatestDownloadedVersion(@NotNull CliTool type);
 }

--- a/plugin-core/src/main/java/appland/cli/AppMapDownloadStatus.java
+++ b/plugin-core/src/main/java/appland/cli/AppMapDownloadStatus.java
@@ -1,0 +1,20 @@
+package appland.cli;
+
+public enum AppMapDownloadStatus {
+    /**
+     * The download was successful.
+     */
+    Successful,
+    /**
+     * The download failed with an error.
+     */
+    Failed,
+    /**
+     * The download was skipped, e.g. because the DeploymentSettings prohibited it.
+     */
+    Skipped;
+
+    public boolean isSuccessful() {
+        return Successful.equals(this);
+    }
+}

--- a/plugin-core/src/main/java/appland/cli/CliTool.java
+++ b/plugin-core/src/main/java/appland/cli/CliTool.java
@@ -4,6 +4,10 @@ import appland.AppMapBundle;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * The different CLI tools that can be run.
+ * See {@link CliTools} for helper methods to find binaries of a given type.
+ */
 @Getter
 public enum CliTool {
     AppMap("appmap",
@@ -27,6 +31,12 @@ public enum CliTool {
         this.presentableName = presentableName;
     }
 
+    /**
+     * @param platform "macos", "linux", or "win"
+     * @param arch     "x64" or "arm64"
+     * @return The name of the binary for the given platform and architecture.
+     * The name is used locally and to build the download URL.
+     */
     public @NotNull String getBinaryName(@NotNull String platform, @NotNull String arch) {
         var suffix = "win".equals(platform) ? ".exe" : "";
         return id + "-" + platform + "-" + arch + suffix;

--- a/plugin-core/src/main/java/appland/cli/CliTools.java
+++ b/plugin-core/src/main/java/appland/cli/CliTools.java
@@ -1,0 +1,130 @@
+package appland.cli;
+
+import appland.deployment.AppMapDeploymentSettingsService;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.util.system.CpuArch;
+import com.intellij.util.text.SemVer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static java.nio.file.attribute.PosixFilePermission.*;
+
+public final class CliTools {
+    private static final Logger LOG = Logger.getInstance(CliTools.class);
+    private static final @NotNull Pattern semVerPattern = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(?:-(\\w+))?");
+
+    private CliTools() {
+    }
+
+    /**
+     * @return {@code true} if a binary is available for the given type, either downloaded or bundled.
+     */
+    public static boolean isBinaryAvailable(@NotNull CliTool type) {
+        return CliTools.getBinaryPath(type) != null;
+    }
+
+    /**
+     * @return The path to the binary, if it exists.
+     * All matching bundled binaries and a downloaded binary (if it exists) are searched.
+     * The binary with the highest version number is returned.
+     * If both a bundled binary and the downloaded binary have the highest version, the bundled binary is returned.
+     */
+    public static @Nullable Path getBinaryPath(@NotNull CliTool type) {
+        return getBinaryPath(type, currentPlatform(), currentArch());
+    }
+
+    /**
+     * @return The path to the binary, if it exists.
+     * All matching bundled binaries and a downloaded binary (if it exists) are searched.
+     * The binary with the highest version number is returned.
+     * If both a bundled binary and the downloaded binary have the highest version, the bundled binary is returned.
+     */
+    public static @Nullable Path getBinaryPath(@NotNull CliTool type, @NotNull String platform, @NotNull String arch) {
+        var downloadedBinary = AppLandDownloadService.getInstance().getDownloadFilePath(type, platform, arch);
+        var bestBundledBinary = AppMapDeploymentSettingsService.getInstance()
+                .findBundledBinaries(type, platform, arch)
+                .filter(Files::exists)
+                .max(pathComparator)
+                .orElse(null);
+
+        if (bestBundledBinary == null) {
+            return downloadedBinary;
+        } else if (downloadedBinary == null) {
+            return bestBundledBinary;
+        }
+
+        // == 0: same version, prefer the bundled binary
+        // < 0: the downloaded binary has a lower version, prefer the bundled binary
+        int compareValue = pathComparator.compare(downloadedBinary, bestBundledBinary);
+        var selectedBinary = compareValue == 0 || compareValue < 0
+                ? bestBundledBinary
+                : downloadedBinary;
+
+        try {
+            fixBinaryPermissions(selectedBinary);
+            return selectedBinary;
+        } catch (IOException e) {
+            LOG.warn("Failed to make the binary executable. Path: " + selectedBinary, e);
+            return null;
+        }
+    }
+
+    public static final @NotNull Comparator<Path> pathComparator = Comparator.comparing(
+            path -> extractVersion(path.toString()),
+            SemVerComparator.INSTANCE);
+
+    /**
+     * package-visible for our tests
+     */
+    public static @NotNull String currentPlatform() {
+        if (SystemInfo.isLinux) {
+            return "linux";
+        }
+
+        if (SystemInfo.isMac) {
+            return "macos";
+        }
+
+        if (SystemInfo.isWindows) {
+            return "win";
+        }
+
+        throw new IllegalStateException("Unsupported platform: " + SystemInfo.getOsNameAndVersion());
+    }
+
+    /**
+     * package-visible for our tests
+     */
+    public static @NotNull String currentArch() {
+        return CpuArch.isArm64() ? "arm64" : "x64";
+    }
+
+    /**
+     * @return The first SemVer match in the given string, or {@code null} if there is no match.
+     */
+    public static @Nullable SemVer extractVersion(@NotNull String value) {
+        var matcher = semVerPattern.matcher(value);
+        if (matcher.find()) {
+            return SemVer.parseFromText(value.substring(matcher.start(), matcher.end()));
+        }
+        return null;
+    }
+
+    /**
+     * On Unix systems, if the file is not yet executable, set the permissions of the given file to 744.
+     * On Windows, do nothing.
+     */
+    public static void fixBinaryPermissions(Path downloadTargetFilePath) throws IOException {
+        if (SystemInfo.isUnix && !Files.isExecutable(downloadTargetFilePath)) {
+            Files.setPosixFilePermissions(downloadTargetFilePath, Set.of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE, GROUP_READ, OTHERS_READ));
+        }
+    }
+}

--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -358,7 +358,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
             return null;
         }
 
-        var indexerPath = AppLandDownloadService.getInstance().getDownloadFilePath(CliTool.AppMap);
+        var indexerPath = CliTools.getBinaryPath(CliTool.AppMap);
         if (indexerPath == null || Files.notExists(indexerPath)) {
             return null;
         }
@@ -396,7 +396,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
             return null;
         }
 
-        var scannerPath = AppLandDownloadService.getInstance().getDownloadFilePath(CliTool.Scanner);
+        var scannerPath = CliTools.getBinaryPath(CliTool.Scanner);
         if (scannerPath == null || Files.notExists(scannerPath)) {
             return null;
         }
@@ -555,7 +555,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
     }
 
     private static @Nullable GeneralCommandLine createAppMapCliCommand(boolean createPtyCommandLine, @NotNull String... parameters) {
-        var toolPath = AppLandDownloadService.getInstance().getDownloadFilePath(CliTool.AppMap);
+        var toolPath = CliTools.getBinaryPath(CliTool.AppMap);
         if (toolPath == null || Files.notExists(toolPath)) {
             LOG.debug("AppMap CLI executable not found: " + toolPath);
             return null;

--- a/plugin-core/src/main/java/appland/cli/DownloadToolsStartupActivity.java
+++ b/plugin-core/src/main/java/appland/cli/DownloadToolsStartupActivity.java
@@ -1,6 +1,8 @@
 package appland.cli;
 
 import appland.ProjectActivityAdapter;
+import appland.notifications.AppMapNotifications;
+import appland.settings.DownloadSettings;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAware;
@@ -26,6 +28,12 @@ public class DownloadToolsStartupActivity extends ProjectActivityAdapter impleme
 
         if (ACTIVE.compareAndSet(false, true)) {
             try {
+                if (DownloadSettings.isAssetDownloadDisabled() && CliTools.getBinaryPath(CliTool.AppMap) == null) {
+                    // Show a notification but still continue with queueDownloadTasks avoid assumptions about its
+                    // implementation.
+                    AppMapNotifications.showAppMapBinaryUnavailableNotification(project);
+                }
+
                 AppLandDownloadService.getInstance().queueDownloadTasks(project);
             } catch (IOException e) {
                 LOG.warn("Download of CLI binaries failed", e);

--- a/plugin-core/src/main/java/appland/cli/FailedDownloadNotificationListener.java
+++ b/plugin-core/src/main/java/appland/cli/FailedDownloadNotificationListener.java
@@ -12,8 +12,8 @@ public final class FailedDownloadNotificationListener implements AppLandDownload
     }
 
     @Override
-    public void downloadFinished(@NotNull CliTool type, boolean success) {
-        if (!success) {
+    public void downloadFinished(@NotNull CliTool type, @NotNull AppMapDownloadStatus status) {
+        if (!status.isSuccessful()) {
             AppMapNotifications.showFailedCliBinaryDownloadNotification(project);
         }
     }

--- a/plugin-core/src/main/java/appland/cli/RegisterContentRootsActivity.java
+++ b/plugin-core/src/main/java/appland/cli/RegisterContentRootsActivity.java
@@ -32,8 +32,7 @@ public class RegisterContentRootsActivity extends ProjectActivityAdapter {
     }
 
     private void launchProcesses(@NotNull Project project) {
-        var downloadService = AppLandDownloadService.getInstance();
-        if (!downloadService.isDownloaded(CliTool.AppMap) || !downloadService.isDownloaded(CliTool.Scanner)) {
+        if (!CliTools.isBinaryAvailable(CliTool.AppMap) || !CliTools.isBinaryAvailable(CliTool.Scanner)) {
             LOG.debug("Skipping launch of processes because tools are unavailable");
             return;
         }

--- a/plugin-core/src/main/java/appland/cli/SemVerComparator.java
+++ b/plugin-core/src/main/java/appland/cli/SemVerComparator.java
@@ -1,0 +1,20 @@
+package appland.cli;
+
+import com.intellij.util.text.SemVer;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Comparator;
+
+public final class SemVerComparator implements Comparator<@Nullable SemVer> {
+    public static final SemVerComparator INSTANCE = new SemVerComparator();
+
+    @Override
+    public int compare(@Nullable SemVer o1, @Nullable SemVer o2) {
+        // sort null to the end
+        if (o1 == null && o2 == null) return 0;
+        if (o1 == null) return 1;
+        if (o2 == null) return -1;
+
+        return o1.compareTo(o2);
+    }
+}

--- a/plugin-core/src/main/java/appland/cli/StartServicesAfterDownloadListener.java
+++ b/plugin-core/src/main/java/appland/cli/StartServicesAfterDownloadListener.java
@@ -5,8 +5,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class StartServicesAfterDownloadListener implements AppLandDownloadListener {
     @Override
-    public void downloadFinished(@NotNull CliTool type, boolean success) {
-        if (!success) {
+    public void downloadFinished(@NotNull CliTool type, @NotNull AppMapDownloadStatus status) {
+        if (!status.isSuccessful()) {
             return;
         }
 
@@ -15,8 +15,7 @@ public class StartServicesAfterDownloadListener implements AppLandDownloadListen
             return;
         }
 
-        var service = AppLandDownloadService.getInstance();
-        if (service.isDownloaded(CliTool.AppMap) && service.isDownloaded(CliTool.Scanner)) {
+        if (CliTools.isBinaryAvailable(CliTool.AppMap) && CliTools.isBinaryAvailable(CliTool.Scanner)) {
             AppLandCommandLineService.getInstance().refreshForOpenProjectsInBackground();
         }
     }

--- a/plugin-core/src/main/java/appland/deployment/AppMapDeploymentSettings.java
+++ b/plugin-core/src/main/java/appland/deployment/AppMapDeploymentSettings.java
@@ -12,10 +12,17 @@ import org.jetbrains.annotations.Nullable;
 public final class AppMapDeploymentSettings {
     @SerializedName("appMap.telemetry")
     @Nullable
-    AppMapDeploymentTelemetrySettings telemetry;
+    private AppMapDeploymentTelemetrySettings telemetry;
+
+    @SerializedName("appMap.autoUpdateTools")
+    private boolean autoUpdateTools = true;
+
+    public AppMapDeploymentSettings(@Nullable AppMapDeploymentTelemetrySettings telemetry) {
+        this(telemetry, true);
+    }
 
     public boolean isEmpty() {
-        return this.telemetry == null;
+        return this.telemetry == null && autoUpdateTools;
     }
 }
 

--- a/plugin-core/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadService.java
+++ b/plugin-core/src/main/java/appland/javaAgent/AppMapJavaAgentDownloadService.java
@@ -2,6 +2,7 @@ package appland.javaAgent;
 
 import appland.AppMapBundle;
 import appland.AppMapPlugin;
+import appland.settings.DownloadSettings;
 import appland.utils.SystemProperties;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
@@ -91,6 +92,11 @@ public final class AppMapJavaAgentDownloadService {
     }
 
     public boolean downloadJavaAgentSync(@NotNull ProgressIndicator indicator) throws IOException {
+        if (!DownloadSettings.isAssetDownloadEnabled()) {
+            LOG.info("asset download disabled, not downloading");
+            return false;
+        }
+
         var agentFilePath = getOrCreateAgentFilePath();
         if (agentFilePath == null) {
             LOG.warn("unable to locate target file path for AppMap Java agent");

--- a/plugin-core/src/main/java/appland/javaAgent/JavaAgentStatus.java
+++ b/plugin-core/src/main/java/appland/javaAgent/JavaAgentStatus.java
@@ -42,16 +42,16 @@ public class JavaAgentStatus {
         SemVer downloadedVersion = getDownloadedVersion();
         SemVer latestAssetVersion = getLatestAssetVersion(indicator);
 
-        String downloadedVersionText = "Your version: ";
-        downloadedVersionText += downloadedVersion == null ? "Unable to locate" : downloadedVersion;
+        String localVersionText = "Your version: ";
+        localVersionText += downloadedVersion == null ? "Unable to locate" : downloadedVersion;
 
-        Path downloadLocation = getResolvedAgentFilePath();
-        downloadedVersionText += downloadLocation == null ? "" : String.format("\n\nDownload location: %s", downloadLocation);
+        Path localLocation = getResolvedAgentFilePath();
+        localVersionText += localLocation == null ? "" : String.format("\n\nLocation: %s", localLocation);
 
         String latestVersionText = String.format("Latest version: %s",
                 latestAssetVersion == null ? "Failed to check for the latest version" : latestAssetVersion);
 
-        return "### AppMap Java Agent Status\n\n" + latestVersionText + "\n\n" + downloadedVersionText + "\n\n";
+        return "### AppMap Java Agent Status\n\n" + latestVersionText + "\n\n" + localVersionText + "\n\n";
     }
 
     private static @Nullable SemVer getDownloadedVersion() {

--- a/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
+++ b/plugin-core/src/main/java/appland/notifications/AppMapNotifications.java
@@ -5,6 +5,7 @@ import appland.AppMapPlugin;
 import appland.actions.StopAppMapRecordingAction;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapProjectConfigurable;
+import appland.settings.DownloadSettings;
 import appland.startup.FirstAppMapLaunchStartupActivity;
 import appland.webviews.navie.NavieEditorProvider;
 import com.intellij.ide.BrowserUtil;
@@ -157,6 +158,30 @@ public final class AppMapNotifications {
                     null, null, AppMapBundle.get("notification.appMapSignIn.content"),
                     NotificationType.INFORMATION, null
             );
+            notification.notify(project);
+        });
+    }
+
+    public static void showAppMapBinaryUnavailableNotification(@NotNull Project project) {
+        EdtInvocationManager.invokeLaterIfNeeded(() -> {
+            var isDownloadEnabled = DownloadSettings.isAssetDownloadEnabled();
+            var content = isDownloadEnabled
+                    ? AppMapBundle.get("notification.appMapBinaryUnavailable.content.downloadEnabled")
+                    : AppMapBundle.get("notification.appMapBinaryUnavailable.content.downloadDisabled");
+
+            var notification = new AppMapFullContentNotification(
+                    GENERIC_NOTIFICATIONS_ID, null,
+                    AppMapBundle.get("notification.appMapBinaryUnavailable.title"), null, content,
+                    NotificationType.WARNING, null
+            );
+
+            if (!isDownloadEnabled) {
+                var actionLabel = AppMapBundle.get("notification.navieUnavailable.content.downloadsDisabled.showSettings");
+                notification.addAction(NotificationAction.createSimpleExpiring(actionLabel, () -> {
+                    ShowSettingsUtil.getInstance().showSettingsDialog(project, AppMapProjectConfigurable.class);
+                }));
+            }
+
             notification.notify(project);
         });
     }

--- a/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
+++ b/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
@@ -1,9 +1,6 @@
 package appland.rpcService;
 
-import appland.cli.AppLandCommandLineService;
-import appland.cli.AppLandDownloadListener;
-import appland.cli.AppLandModelInfoProvider;
-import appland.cli.CliTool;
+import appland.cli.*;
 import appland.config.AppMapConfigFileListener;
 import appland.files.AppMapFiles;
 import appland.settings.AppMapApplicationSettingsService;
@@ -34,12 +31,6 @@ import com.intellij.util.concurrency.annotations.RequiresBackgroundThread;
 import com.intellij.util.concurrency.annotations.RequiresReadLock;
 import com.intellij.util.io.BaseOutputReader;
 import com.intellij.util.io.HttpRequests;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import appland.rpcService.NavieThreadQueryV1Params;
-import appland.rpcService.NavieThreadQueryV1Response;
 import lombok.Data;
 import net.jcip.annotations.GuardedBy;
 import org.jetbrains.annotations.NotNull;
@@ -347,8 +338,8 @@ public class DefaultAppLandJsonRpcService implements AppLandJsonRpcService, AppL
     }
 
     @Override
-    public void downloadFinished(@NotNull CliTool type, boolean success) {
-        if (success && CliTool.AppMap.equals(type) && !isServerRunning()) {
+    public void downloadFinished(@NotNull CliTool type, @NotNull AppMapDownloadStatus status) {
+        if (status.isSuccessful() && CliTool.AppMap.equals(type) && !isServerRunning()) {
             restartServerAsync();
         }
     }

--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -78,6 +78,15 @@ public class AppMapApplicationSettings {
     @Setter(AccessLevel.NONE)
     private volatile HashMap<String, String> modelConfig = new HashMap<>();
 
+    /**
+     * Turn on the automatic download of AppMap assets if this setting is {@code true}.
+     * Turn off the automatic download if this setting is {@code false}.
+     * If the value is {@code null}, the default behavior is controlled
+     * by the {@link appland.deployment.AppMapDeploymentSettings#autoUpdateTools} property.
+     * If there are no deployment settings, then the default behavior is to automatically update tools.
+     */
+    private volatile @Nullable Boolean autoUpdateTools = null;
+
     public AppMapApplicationSettings() {
     }
 
@@ -99,6 +108,7 @@ public class AppMapApplicationSettings {
         this.showFailedCliDownloadError = settings.showFailedCliDownloadError;
         this.selectedAppMapModel = settings.selectedAppMapModel;
         this.modelConfig.putAll(settings.modelConfig);
+        this.autoUpdateTools = settings.autoUpdateTools;
     }
 
     public @NotNull Map<String, String> getCliEnvironment() {
@@ -207,6 +217,15 @@ public class AppMapApplicationSettings {
 
         if (!Objects.equals(oldValue, value)) {
             ApplicationManager.getApplication().executeOnPooledThread(settingsPublisher()::modelConfigChange);
+        }
+    }
+
+    public void setAutoUpdateToolsNotifying(@Nullable Boolean autoUpdateTools) {
+        var changed = !Objects.equals(autoUpdateTools, this.autoUpdateTools);
+        this.autoUpdateTools = autoUpdateTools;
+
+        if (changed) {
+            settingsPublisher().autoUpdateToolsChanged();
         }
     }
 

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsListener.java
@@ -50,4 +50,7 @@ public interface AppMapSettingsListener {
 
     default void selectedAppMapModelChanged() {
     }
+
+    default void autoUpdateToolsChanged() {
+    }
 }

--- a/plugin-core/src/main/java/appland/settings/AutoDownloadSettingsListener.java
+++ b/plugin-core/src/main/java/appland/settings/AutoDownloadSettingsListener.java
@@ -1,0 +1,36 @@
+package appland.settings;
+
+import appland.cli.AppLandDownloadService;
+import appland.javaAgent.AppMapJavaAgentDownloadService;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+public class AutoDownloadSettingsListener implements AppMapSettingsListener {
+    private static final Logger LOG = Logger.getInstance(AutoDownloadSettingsListener.class);
+
+    @NotNull private final Project project;
+
+    public AutoDownloadSettingsListener(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public void autoUpdateToolsChanged() {
+        if (DownloadSettings.isAssetDownloadEnabled()) {
+            try {
+                AppLandDownloadService.getInstance().queueDownloadTasks(project);
+            } catch (IOException e) {
+                LOG.warn("Failed to download AppMap CLI assets", e);
+            }
+
+            try {
+                AppMapJavaAgentDownloadService.getInstance().downloadJavaAgent(project);
+            } catch (Exception e) {
+                LOG.warn("Failed to download AppMap Java agent", e);
+            }
+        }
+    }
+}

--- a/plugin-core/src/main/java/appland/settings/DownloadSettings.java
+++ b/plugin-core/src/main/java/appland/settings/DownloadSettings.java
@@ -1,0 +1,24 @@
+package appland.settings;
+
+import appland.deployment.AppMapDeploymentSettingsService;
+
+public final class DownloadSettings {
+    private DownloadSettings() {
+    }
+
+    /**
+     * Returns whether the download of AppMap assets is enabled.
+     *
+     * @return {@code true} if the download is enabled, {@code false} otherwise.
+     */
+    public static boolean isAssetDownloadEnabled() {
+        var userOverride = AppMapApplicationSettingsService.getInstance().getAutoUpdateTools();
+        return userOverride != null
+                ? userOverride
+                : AppMapDeploymentSettingsService.getCachedDeploymentSettings().isAutoUpdateTools();
+    }
+
+    public static boolean isAssetDownloadDisabled() {
+        return !isAssetDownloadEnabled();
+    }
+}

--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditorProvider.java
@@ -2,6 +2,8 @@ package appland.webviews.navie;
 
 import appland.AppMapBundle;
 import appland.Icons;
+import appland.cli.CliTool;
+import appland.cli.CliTools;
 import appland.notifications.AppMapNotifications;
 import appland.rpcService.AppLandJsonRpcService;
 import appland.settings.AppMapProjectSettingsService;
@@ -101,6 +103,7 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
             return null;
         }));
     }
+
     /**
      * Opens the Navie webview focusing an existing thread by ID.
      */
@@ -125,6 +128,11 @@ public final class NavieEditorProvider extends WebviewEditorProvider {
     public static void openEditor(@NotNull Project project, @NotNull DataContext context) {
         var provider = WebviewEditorProvider.findEditorProvider(TYPE_ID);
         assert provider != null;
+
+        if (CliTools.getBinaryPath(CliTool.AppMap) == null) {
+            AppMapNotifications.showAppMapBinaryUnavailableNotification(project);
+            return;
+        }
 
         var editor = CommonDataKeys.EDITOR_EVEN_IF_INACTIVE.getData(context);
         chooseIndexerJsonRpcPort(project, editor, (indexerPort, codeSelection) -> {

--- a/plugin-core/src/main/resources/META-INF/appmap-core.xml
+++ b/plugin-core/src/main/resources/META-INF/appmap-core.xml
@@ -21,6 +21,10 @@
         <listener topic="com.intellij.ide.plugins.DynamicPluginListener"
                   class="appland.startup.DynamicPluginListener"/>
 
+        <listener topic="appland.settings.AppMapSettingsListener"
+                  class="appland.settings.AutoDownloadSettingsListener"
+                  activeInTestMode="false"/>
+
         <listener topic="appland.cli.AppLandDownloadListener"
                   class="appland.cli.StartServicesAfterDownloadListener"/>
 

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -154,7 +154,7 @@ notification.firstAppMap.openAction=View your AppMaps
 
 notification.appMapSignIn.content=Logged into AppMap
 
-notification.navieUnavailable.content=AppMap Explain is not ready yet. Please try again in a few seconds.
+notification.navieUnavailable.content=AppMap Navie is not ready yet. Please try again in a few seconds.
 
 notification.naviePinnedFileTooLarge.title=AppMap
 notification.naviePinnedFileTooLarge.content={0,choice,1#One pinned file exceeds|1<{0,number,integer} pinned files exceed} the maximum file size of {1,number,integer} KB.
@@ -172,6 +172,11 @@ notification.reloadProject.content=Please reload your project because the AppMap
 notification.cliDownloadFailed.title=Download Failed: AppMap CLI Tools
 notification.cliDownloadFailed.content=Failed to download the AppMap CLI tools. This is a required dependency of the AppMap plugin. Please refer to the instructions to manually install it.
 notification.cliDownloadFailed.browseAction=Show instructions
+
+notification.appMapBinaryUnavailable.title=AppMap
+notification.appMapBinaryUnavailable.content.downloadEnabled=The AppMap CLI binary is unavailable or could not be downloaded.
+notification.appMapBinaryUnavailable.content.downloadDisabled=The AppMap CLI binary is unavailable, and downloads have been turned off in the settings. AppMap Navie and other features will be unavailable.
+notification.navieUnavailable.content.downloadsDisabled.showSettings=Show AppMap settings
 
 statusBar.recording.displayName=AppMap Recording
 statusBar.recording.recordingStatus=Recording...
@@ -200,6 +205,10 @@ projectSettings.maxPinnedFileSize.label=Max Pinned File Size:
 projectSettings.maxPinnedFileSize.comment=Maximum size of a file (in KB) that can be pinned to the Navie context.
 projectSettings.maxPinnedFileSize.unit=KB
 projectSettings.useAnimation.title=Use animation
+projectSettings.automaticToolsUpdate.title=Automatically download tools:
+projectSettings.automaticToolsUpdate.deploymentDefault=Default from deployment settings
+projectSettings.automaticToolsUpdate.enabled=Yes
+projectSettings.automaticToolsUpdate.disabled=No
 
 installGuide.editor.title=Using AppMap
 installGuide.pageInstallAgent.title=Add AppMap to your project
@@ -246,7 +255,7 @@ webview.findingDetails.locationNotFound.message=The source file could not be fou
 webview.findingDetails.appMapNotFound.title=AppMap Not Found
 webview.findingDetails.appMapNotFound.message=The AppMap file could not be found.
 
-webview.navie.title=AppMap AI: Explain
+webview.navie.title=AppMap Navie
 webview.navie.chooseAppMapModule.title=Choose AppMap module
 webview.navie.updatingMostRecentAppMaps=Locating most recent AppMaps...
 webview.navie.webviewBroken.title=AppMap Navie
@@ -290,3 +299,4 @@ notification.copilotAuthRequired.content=Please authenticate GitHub Copilot to u
 notification.copilotExclusionDownloadFailed.title=AppMap Copilot Integration
 notification.copilotExclusionDownloadFailed.subtitle=Error
 notification.copilotExclusionDownloadFailed.content=Content exclusion policy download from GitHub failed:<br>{0}<br>Please try again later.
+projectSettings.automaticToolsUpdate.deploymentDefaultComment=Default: {0}

--- a/plugin-core/src/test/java/appland/AppMapDeploymentTestUtils.java
+++ b/plugin-core/src/test/java/appland/AppMapDeploymentTestUtils.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Utilities to test with a specific AppMap deployment setup.
@@ -44,6 +45,29 @@ public final class AppMapDeploymentTestUtils {
             Files.deleteIfExists(jsonFile);
 
             AppMapDeploymentSettingsService.reset();
+        }
+    }
+
+    /**
+     * Copies the given binaries to the directory, where bundled binaries are searched, executes the runnable, and finally deletes the copied binaries.
+     * The binaries must be removed to avoid side-effects on other tests.
+     *
+     * @param binariesToBundle The binaries to copy to the directory.
+     */
+    public static void withBundledBinaries(@NotNull List<Path> binariesToBundle, @NotNull ThrowableRunnable<Exception> runnable) throws Exception {
+        var parentDirectory = AppMapDeploymentSettingsService.bundledBinarySearchPath().get(0);
+        Files.createDirectories(parentDirectory);
+
+        try {
+            for (var binary : binariesToBundle) {
+                Files.copy(binary, parentDirectory.resolve(binary.getFileName()));
+            }
+
+            runnable.run();
+        } finally {
+            for (var binary : binariesToBundle) {
+                Files.deleteIfExists(parentDirectory.resolve(binary.getFileName()));
+            }
         }
     }
 }

--- a/plugin-core/src/test/java/appland/cli/AppMapUtilTest.java
+++ b/plugin-core/src/test/java/appland/cli/AppMapUtilTest.java
@@ -1,0 +1,15 @@
+package appland.cli;
+
+import appland.AppMapBaseTest;
+import com.intellij.util.text.SemVer;
+import org.junit.Test;
+
+public class AppMapUtilTest extends AppMapBaseTest {
+    @Test
+    public void semVerFromPath() {
+        assertEquals(new SemVer("1.2.3", 1, 2, 3), CliTools.extractVersion("appmap-linux-x64-1.2.3.exe"));
+        assertEquals(new SemVer("1.2.3", 1, 2, 3), CliTools.extractVersion("/home/user/.appmap/appmap-linux-x64-1.2.3"));
+        assertEquals(new SemVer("1.2.3", 1, 2, 3), CliTools.extractVersion("C:\\Users\\appmap\\binaries\\appmap-linux-x64-1.2.3.exe"));
+        assertNull(CliTools.extractVersion("appmap-linux-x64.exe"));
+    }
+}

--- a/plugin-core/src/test/java/appland/cli/CliToolsTest.java
+++ b/plugin-core/src/test/java/appland/cli/CliToolsTest.java
@@ -1,0 +1,100 @@
+package appland.cli;
+
+import appland.AppMapBaseTest;
+import appland.AppMapDeploymentTestUtils;
+import appland.deployment.AppMapDeploymentSettingsService;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.testFramework.fixtures.TempDirTestFixture;
+import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class CliToolsTest extends AppMapBaseTest {
+    @Override
+    public TempDirTestFixture createTempDirTestFixture() {
+        // create temp files on disk
+        return new TempDirTestFixtureImpl();
+    }
+
+    @Override
+    protected boolean runInDispatchThread() {
+        return false;
+    }
+
+    @Test
+    public void bestBinarySearch() throws Exception {
+        // Mock binaries to copy into the location where bundled binaries are searched
+        // The high version numbers ensure that a binary downloaded by our tests are not returned.
+        var appmapBinaries = List.of(
+                createMockBinary("appmap-win-x64-v1000.2.0.exe"),
+                createMockBinary("appmap-win-x64-v1000.1.123.exe"),
+                createMockBinary("appmap-win-arm64-v1000.2.0.exe"),
+                createMockBinary("appmap-win-arm64-v1000.1.123.exe"),
+
+                createMockBinary("appmap-linux-x64-v1000.2.0"),
+                createMockBinary("appmap-linux-x64-v1000.1.123"),
+                createMockBinary("appmap-linux-arm64-v1000.2.0"),
+                createMockBinary("appmap-linux-arm64-v1000.1.123"),
+
+                createMockBinary("appmap-macos-x64-v1000.2.0"),
+                createMockBinary("appmap-macos-x64-v1000.1.123"),
+                createMockBinary("appmap-macos-arm64-v1000.2.0"),
+                createMockBinary("appmap-macos-arm64-v1000.1.123")
+        );
+
+        AppMapDeploymentTestUtils.withBundledBinaries(appmapBinaries, () -> {
+            assertNotNull("There must be a match for every platform", CliTools.getBinaryPath(CliTool.AppMap));
+
+            var windowsMatch = CliTools.getBinaryPath(CliTool.AppMap, "win", "x64");
+            assertNotNull(windowsMatch);
+            assertEquals("appmap-win-x64-v1000.2.0.exe", windowsMatch.getFileName().toString());
+
+            var macosMatch = CliTools.getBinaryPath(CliTool.AppMap, "macos", "arm64");
+            assertNotNull(macosMatch);
+            assertEquals("appmap-macos-arm64-v1000.2.0", macosMatch.getFileName().toString());
+            if (SystemInfo.isMac) {
+                assertTrue(Files.isExecutable(macosMatch));
+            }
+
+            var linuxMatch = CliTools.getBinaryPath(CliTool.AppMap, "linux", "x64");
+            assertNotNull(linuxMatch);
+            assertEquals("appmap-linux-x64-v1000.2.0", linuxMatch.getFileName().toString());
+            if (SystemInfo.isLinux) {
+                assertTrue(Files.isExecutable(linuxMatch));
+            }
+        });
+    }
+
+    @Test
+    public void bundledBinaryIsPreferred() throws Exception {
+        TestAppLandDownloadService.ensureDownloaded();
+
+        var downloadedAppMapBinary = AppLandDownloadService.getInstance().getDownloadFilePath(CliTool.AppMap,
+                CliTools.currentPlatform(),
+                CliTools.currentArch());
+        assertNotNull(downloadedAppMapBinary);
+
+        var bundledBinary = createMockBinary(downloadedAppMapBinary.getFileName().toString());
+
+        AppMapDeploymentTestUtils.withBundledBinaries(List.of(bundledBinary), () -> {
+            var bestMatch = CliTools.getBinaryPath(CliTool.AppMap);
+            assertNotNull(bestMatch);
+            assertEquals(bundledBinary.getFileName().toString(), bestMatch.getFileName().toString());
+
+            var binaryParentDir = AppMapDeploymentSettingsService.bundledBinarySearchPath().stream().findFirst().orElse(null);
+            assertNotNull(binaryParentDir);
+            assertEquals(
+                    "Bundled binaries should be preferred over downloaded binaries",
+                    binaryParentDir.resolve(bestMatch.getFileName()),
+                    bestMatch);
+        });
+    }
+
+    private @NotNull Path createMockBinary(String filename) {
+        return myFixture.getTempDirFixture().createFile(filename).toNioPath();
+    }
+}

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
@@ -13,8 +13,8 @@ import org.mockserver.model.HttpResponse;
 
 import java.util.Arrays;
 
-import static appland.cli.DefaultAppLandDownloadService.currentArch;
-import static appland.cli.DefaultAppLandDownloadService.currentPlatform;
+import static appland.cli.CliTools.currentArch;
+import static appland.cli.CliTools.currentPlatform;
 
 public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
     @Rule
@@ -45,7 +45,7 @@ public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
                 .respond(HttpResponse.response().withBody(""));
 
         // Perform the download using the mock HTTP proxy server
-        AppLandDownloadServiceTestUtil.downloadLatestCliVersions(getProject(), toolType, getTestRootDisposable());
+        AppLandDownloadServiceTestUtil.assertDownloadLatestCliVersions(getProject(), toolType, getTestRootDisposable());
 
         var hasDownloadRequest = Arrays.stream(mockServerRule.getClient().retrieveRecordedRequests(null))
                 .anyMatch(request -> {

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
@@ -1,6 +1,8 @@
 package appland.cli;
 
 import appland.AppMapBaseTest;
+import appland.AppMapDeploymentTestUtils;
+import appland.deployment.AppMapDeploymentSettings;
 import com.intellij.testFramework.VfsTestUtil;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
@@ -38,7 +40,15 @@ public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
     public void downloadAppMapBinary() throws Exception {
         // We're only testing the download of the AppMap tool and not of the scanner
         // because they work in the same way, and we don't want to extend the test duration unnecessarily.
-        AppLandDownloadServiceTestUtil.downloadLatestCliVersions(getProject(), CliTool.AppMap, getTestRootDisposable());
+        AppLandDownloadServiceTestUtil.assertDownloadLatestCliVersions(getProject(), CliTool.AppMap, getTestRootDisposable());
+    }
+
+    @Test
+    public void downloadAppMapBinaryWithProhibitingDeploymentSettings() throws Exception {
+        AppMapDeploymentTestUtils.withSiteConfigFile(new AppMapDeploymentSettings(null, false), () -> {
+            var status = AppLandDownloadServiceTestUtil.downloadLatestCliVersions(getProject(), CliTool.AppMap, getTestRootDisposable());
+            assertEquals(AppMapDownloadStatus.Skipped, status);
+        });
     }
 
     @Test

--- a/plugin-core/src/test/java/appland/cli/SemVerComparatorTest.java
+++ b/plugin-core/src/test/java/appland/cli/SemVerComparatorTest.java
@@ -1,0 +1,19 @@
+package appland.cli;
+
+import appland.AppMapBaseTest;
+import com.intellij.util.text.SemVer;
+import org.junit.Test;
+
+public class SemVerComparatorTest extends AppMapBaseTest {
+    @Test
+    public void comparator() {
+        var comparator = SemVerComparator.INSTANCE;
+        assertEquals(0, comparator.compare(SemVer.parseFromText("1.2.3"), SemVer.parseFromText("1.2.3")));
+        assertEquals(1, comparator.compare(null, SemVer.parseFromText("1.2.3")));
+        assertEquals(-1, comparator.compare(SemVer.parseFromText("1.2.3"), null));
+
+        assertEquals(1, comparator.compare(SemVer.parseFromText("2.0.0"), SemVer.parseFromText("1.2.3")));
+        assertEquals(-1, comparator.compare(SemVer.parseFromText("1.2.3"), SemVer.parseFromText("2.0.0")));
+        assertEquals(1, comparator.compare(SemVer.parseFromText("1.3.0"), SemVer.parseFromText("1.2.999")));
+    }
+}

--- a/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
+++ b/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
@@ -8,12 +8,12 @@ import com.intellij.openapi.progress.EmptyProgressIndicator;
 public class TestAppLandDownloadService extends DefaultAppLandDownloadService {
     public static void ensureDownloaded() {
         var service = (TestAppLandDownloadService) AppLandDownloadService.getInstance();
-        for (var value : CliTool.values()) {
-            if (!service.isDownloaded(value)) {
-                var version = service.fetchLatestRemoteVersion(value);
+        for (var type : CliTool.values()) {
+            if (service.findLatestDownloadedVersion(type) == null) {
+                var version = service.fetchLatestRemoteVersion(type);
                 assert version != null;
 
-                service.download(value, version, new EmptyProgressIndicator());
+                service.download(type, version, new EmptyProgressIndicator());
             }
         }
     }

--- a/plugin-core/src/test/java/appland/deployment/AppMapDeploymentSettingsServiceTest.java
+++ b/plugin-core/src/test/java/appland/deployment/AppMapDeploymentSettingsServiceTest.java
@@ -2,10 +2,15 @@ package appland.deployment;
 
 import appland.AppMapBaseTest;
 import appland.AppMapPlugin;
+import appland.cli.CliTool;
+import appland.cli.CliTools;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static appland.AppMapDeploymentTestUtils.withSiteConfigFile;
@@ -15,6 +20,48 @@ public class AppMapDeploymentSettingsServiceTest extends AppMapBaseTest {
     protected TempDirTestFixture createTempDirTestFixture() {
         // create temp files on disk
         return new TempDirTestFixtureImpl();
+    }
+
+    @Test
+    public void defaultStatus() {
+        assertTrue(
+                "By default, downloads must be permitted",
+                AppMapDeploymentSettingsService.getCachedDeploymentSettings().isAutoUpdateTools()
+        );
+    }
+
+    @Test
+    public void bundledFilesSelection() throws IOException {
+        var baseDir = Path.of(myFixture.getTempDirPath()).resolve("bundledBinaries");
+        Files.createDirectories(baseDir);
+
+        createMockBinaries(baseDir, CliTool.AppMap, 0, "win", "x64", ".exe");
+        createMockBinaries(baseDir, CliTool.AppMap, 1, "win", "arm64", ".exe");
+        createMockBinaries(baseDir, CliTool.AppMap, 2, "linux", "x64", "");
+        createMockBinaries(baseDir, CliTool.AppMap, 3, "linux", "arm64", "");
+        createMockBinaries(baseDir, CliTool.AppMap, 4, "macos", "x64", "");
+        createMockBinaries(baseDir, CliTool.AppMap, 5, "macos", "arm64", "");
+
+        createMockBinaries(baseDir, CliTool.Scanner, 0, "win", "x64", ".exe");
+        createMockBinaries(baseDir, CliTool.Scanner, 1, "win", "arm64", ".exe");
+        createMockBinaries(baseDir, CliTool.Scanner, 2, "linux", "x64", "");
+        createMockBinaries(baseDir, CliTool.Scanner, 3, "linux", "arm64", "");
+        createMockBinaries(baseDir, CliTool.Scanner, 4, "macos", "x64", "");
+        createMockBinaries(baseDir, CliTool.Scanner, 5, "macos", "arm64", "");
+
+        assertBinaryPath("appmap-win-x64-0.11.0.exe", baseDir, CliTool.AppMap, "win", "x64");
+        assertBinaryPath("appmap-win-arm64-1.11.0.exe", baseDir, CliTool.AppMap, "win", "arm64");
+        assertBinaryPath("appmap-linux-x64-2.11.0", baseDir, CliTool.AppMap, "linux", "x64");
+        assertBinaryPath("appmap-linux-arm64-3.11.0", baseDir, CliTool.AppMap, "linux", "arm64");
+        assertBinaryPath("appmap-macos-x64-4.11.0", baseDir, CliTool.AppMap, "macos", "x64");
+        assertBinaryPath("appmap-macos-arm64-5.11.0", baseDir, CliTool.AppMap, "macos", "arm64");
+
+        assertBinaryPath("scanner-win-x64-0.11.0.exe", baseDir, CliTool.Scanner, "win", "x64");
+        assertBinaryPath("scanner-win-arm64-1.11.0.exe", baseDir, CliTool.Scanner, "win", "arm64");
+        assertBinaryPath("scanner-linux-x64-2.11.0", baseDir, CliTool.Scanner, "linux", "x64");
+        assertBinaryPath("scanner-linux-arm64-3.11.0", baseDir, CliTool.Scanner, "linux", "arm64");
+        assertBinaryPath("scanner-macos-x64-4.11.0", baseDir, CliTool.Scanner, "macos", "x64");
+        assertBinaryPath("scanner-macos-arm64-5.11.0", baseDir, CliTool.Scanner, "macos", "arm64");
     }
 
     @Test
@@ -63,23 +110,28 @@ public class AppMapDeploymentSettingsServiceTest extends AppMapBaseTest {
         });
     }
 
-    @Test
-    public void deploymentConfigurationNestedDirectory() throws Exception {
-        var content = """
-                {
-                  "appMap.telemetry": {
-                    "backend": "splunk",
-                    "url": "https://splunk.example.com:443",
-                    "token": "my-hec-token",
-                    "ca": "system"
-                  }
-                }
-                """;
+    private void createMockBinaries(@NotNull Path baseDir,
+                                    @NotNull CliTool type,
+                                    int majorVersion,
+                                    @NotNull String platform,
+                                    @NotNull String arch,
+                                    @NotNull String suffix) throws IOException {
+        var prefix = type.getId();
+        Files.createFile(baseDir.resolve("%s-%s-%s-%d.1.0%s".formatted(prefix, platform, arch, majorVersion, suffix)));
+        Files.createFile(baseDir.resolve("%s-%s-%s-%d.2.0%s".formatted(prefix, platform, arch, majorVersion, suffix)));
+        Files.createFile(baseDir.resolve("%s-%s-%s-%d.10.0%s".formatted(prefix, platform, arch, majorVersion, suffix)));
+        Files.createFile(baseDir.resolve("%s-%s-%s-%d.11.0%s".formatted(prefix, platform, arch, majorVersion, suffix)));
+    }
 
-        withSiteConfigFile(AppMapPlugin.getPluginPath().resolve("extension"), content, path -> {
-            var parsedSettings = AppMapDeploymentSettingsService.readDeploymentSettings();
-            assertNotNull("Deployment settings must be read from nested extensions dir of the plugin directory", parsedSettings);
-            assertNotNull(parsedSettings.getTelemetry());
-        });
+    private static void assertBinaryPath(@NotNull String expected,
+                                         @NotNull Path baseDir,
+                                         @NotNull CliTool type,
+                                         @NotNull String platform,
+                                         @NotNull String arch) {
+        var appmapBinaries = AppMapDeploymentSettingsService.findBundledBinaries(baseDir, type, platform, arch);
+        assertNotNull(appmapBinaries);
+        var appmapBinary = appmapBinaries.stream().max(CliTools.pathComparator).orElse(null);
+        assertNotNull(appmapBinary);
+        assertEquals(expected, appmapBinary.getFileName().toString());
     }
 }

--- a/plugin-core/src/test/java/appland/deployment/AppMapDeploymentSettingsTest.java
+++ b/plugin-core/src/test/java/appland/deployment/AppMapDeploymentSettingsTest.java
@@ -9,12 +9,30 @@ public class AppMapDeploymentSettingsTest extends AppMapBaseTest {
     public void jsonSerialization() {
         var settings = new AppMapDeploymentSettings(new AppMapDeploymentTelemetrySettings(
                 "splunk", "https://my-splunk.example.com:443", "my-hec-token", "my-ca-cert"
-        ));
+        ), true);
 
         var expectedJson = """
-                {"appMap.telemetry":{"backend":"splunk","url":"https://my-splunk.example.com:443","token":"my-hec-token","ca":"my-ca-cert"}}
+                {"appMap.telemetry":{"backend":"splunk","url":"https://my-splunk.example.com:443","token":"my-hec-token","ca":"my-ca-cert"},"appMap.autoUpdateTools":true}
                 """;
         assertEquals(expectedJson.trim(), GsonUtils.GSON.toJson(settings).trim());
         assertEquals(settings, GsonUtils.GSON.fromJson(expectedJson, AppMapDeploymentSettings.class));
+    }
+
+    @Test
+    public void partialSettingsKeepDefaults() {
+        var json = """
+                {"appmap.telemetry":{"backend":"splunk","url":"https://my-splunk.example.com:443","token":"my-hec-token","ca":"my-ca-cert"}}
+                """;
+        var settings = GsonUtils.GSON.fromJson(json, AppMapDeploymentSettings.class);
+        assertTrue("The default setting must be kept if the JSON did not define it", settings.isAutoUpdateTools());
+    }
+
+    @Test
+    public void nullSettingsKeepDefaults() {
+        var json = """
+                {"appMap.autoUpdateTools": null}
+                """;
+        var settings = GsonUtils.GSON.fromJson(json, AppMapDeploymentSettings.class);
+        assertTrue("The default setting must be kept if the JSON did not define it", settings.isAutoUpdateTools());
     }
 }


### PR DESCRIPTION
Based on #907 , which has to be reviewed and merged first

- Supports binaries bundled with the plugin.zip package, either at `resources` or at `extension/resources`. Only binaries matching the current OS and arch are selected. With multiple matches, the list is sorted based on SemVer and the highest version is selected.
- Downloads of new versions can be turned off via `site-config.json` bundled with the plugin
- README.md is updated with a description of the deployment settings
- If the plugin started with downloads turned off and the user turns it on later, then a new download is requested after the change of the setting
- New gradle task `./gradlew runIdeWithDeploymentSettings` allows to test the plugin with deployment settings. The setting is created at `./build/idea-sandbox-deployment-settings/plugins_runIdeWithDeploymentSettings/intellij-appmap/site-config.json`.

ToDo:
- [x] Test with a real-live distribution package
- [x] Make automatic download  user-configurable
- [x] Apply the download setting to the download of the agent 
- [x] Show notification if no CLI binary is available and downloads are turned off

### New setting to control asset download (without deployment settings):
<img width="1092" height="461" alt="image" src="https://github.com/user-attachments/assets/05d0653b-e054-4142-96d2-ef93596e2a9f" />

### New setting to control asset download (with configured deployment settings):
<img width="1192" height="396" alt="image" src="https://github.com/user-attachments/assets/48b45c1f-cb1b-40ae-9f1b-39225afdc3ef" />

### Notification at startup or if user attempts to open Navie without an AppMap binary and with downloads turned off

At startup, the notification is displayed only once per application session and only in one project. That's the same as with other startup notifications.

<img width="896" height="313" alt="image" src="https://github.com/user-attachments/assets/eb8deb2e-af34-49f3-becf-bbacd2266177" />