### PR TITLE
Better error handling for webview-based editors

### DIFF
--- a/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
+++ b/plugin-core/src/main/java/appland/installGuide/InstallGuideEditor.java
@@ -12,6 +12,7 @@ import appland.settings.AppMapSettingsListener;
 import appland.utils.DataContexts;
 import appland.webviews.OpenExternalLinksHandler;
 import appland.webviews.WebviewEditor;
+import appland.webviews.WebviewEditorException;
 import appland.webviews.findings.FindingsOverviewEditorProvider;
 import appland.webviews.navie.NavieEditorProvider;
 import appland.webviews.navie.NaviePromptSuggestion;
@@ -114,12 +115,12 @@ public class InstallGuideEditor extends WebviewEditor<List<ProjectMetadata>> {
     }
 
     @Override
-    protected @Nullable List<ProjectMetadata> createInitData() {
+    protected @Nullable List<ProjectMetadata> createInitData() throws WebviewEditorException {
         return findProjects();
     }
 
     @Override
-    protected void setupInitMessage(@Nullable List<ProjectMetadata> initData, @NotNull JsonObject payload) {
+    protected void setupInitMessage(@Nullable List<ProjectMetadata> initData, @NotNull JsonObject payload) throws WebviewEditorException {
         addBaseProperties(payload);
         payload.add("projects", gson.toJsonTree(initData));
     }

--- a/plugin-core/src/main/java/appland/webviews/WebviewEditorException.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditorException.java
@@ -1,0 +1,18 @@
+package appland.webviews;
+
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Exception thrown if a {@link WebviewEditor} failed to initialize.
+ * The exception provides an error message, suitable to be shown to the user.
+ */
+public final class WebviewEditorException extends Exception {
+    public WebviewEditorException(@Nls String message) {
+        super(message);
+    }
+
+    public WebviewEditorException(@Nls String message, @NotNull Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/findingDetails/FindingDetailsEditor.java
@@ -6,6 +6,7 @@ import appland.problemsView.FindingsUtil;
 import appland.problemsView.ResolvedStackLocation;
 import appland.utils.GsonUtils;
 import appland.webviews.WebviewEditor;
+import appland.webviews.WebviewEditorException;
 import appland.webviews.appMap.AppMapFileEditorProvider;
 import appland.webviews.appMap.AppMapFileEditorState;
 import appland.webviews.findings.FindingsOverviewEditorProvider;
@@ -75,7 +76,7 @@ public class FindingDetailsEditor extends WebviewEditor<Void> {
     }
 
     @Override
-    protected @Nullable Void createInitData() {
+    protected @Nullable Void createInitData() throws WebviewEditorException {
         return null;
     }
 
@@ -85,7 +86,7 @@ public class FindingDetailsEditor extends WebviewEditor<Void> {
     }
 
     @Override
-    protected void setupInitMessage(@Nullable Void initData, @NotNull JsonObject payload) {
+    protected void setupInitMessage(@Nullable Void initData, @NotNull JsonObject payload) throws WebviewEditorException {
         var findings = FindingDetailsEditorProvider.KEY_FINDINGS.get(file);
         assert findings != null;
 

--- a/plugin-core/src/main/java/appland/webviews/findings/FindingsOverviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/findings/FindingsOverviewEditor.java
@@ -6,6 +6,7 @@ import appland.problemsView.FindingsViewTab;
 import appland.problemsView.model.ScannerFinding;
 import appland.utils.GsonUtils;
 import appland.webviews.WebviewEditor;
+import appland.webviews.WebviewEditorException;
 import appland.webviews.findingDetails.FindingDetailsEditorProvider;
 import appland.webviews.webserver.AppMapWebview;
 import com.google.gson.JsonArray;
@@ -32,7 +33,7 @@ public class FindingsOverviewEditor extends WebviewEditor<List<ScannerFinding>> 
     }
 
     @Override
-    protected void setupInitMessage(@Nullable List<ScannerFinding> initData, @NotNull JsonObject payload) {
+    protected void setupInitMessage(@Nullable List<ScannerFinding> initData, @NotNull JsonObject payload) throws WebviewEditorException {
         assert initData != null;
 
         payload.addProperty("page", "finding-overview");
@@ -59,7 +60,7 @@ public class FindingsOverviewEditor extends WebviewEditor<List<ScannerFinding>> 
         }
     }
 
-    protected @NotNull List<ScannerFinding> createInitData() {
+    protected @NotNull List<ScannerFinding> createInitData() throws WebviewEditorException {
         return FindingsManager.getInstance(project).getAllFindings();
     }
 

--- a/plugin-core/src/main/java/appland/webviews/navie/NavieEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/navie/NavieEditor.java
@@ -18,6 +18,7 @@ import appland.toolwindow.AppMapToolWindowFactory;
 import appland.utils.GsonUtils;
 import appland.webviews.SharedAppMapWebViewMessages;
 import appland.webviews.WebviewEditor;
+import appland.webviews.WebviewEditorException;
 import appland.webviews.appMap.AppMapFileEditorProvider;
 import appland.webviews.appMap.AppMapFileEditorState;
 import appland.webviews.webserver.AppMapWebview;
@@ -48,7 +49,6 @@ import com.intellij.util.Alarm;
 import com.intellij.util.SingleAlarm;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.intellij.util.concurrency.annotations.RequiresEdt;
-import appland.webviews.navie.NavieEditorProvider;
 import com.intellij.util.concurrency.annotations.RequiresReadLock;
 import lombok.Value;
 import org.jetbrains.annotations.Nls;
@@ -114,7 +114,7 @@ public class NavieEditor extends WebviewEditor<Void> {
     }
 
     @Override
-    protected void setupInitMessage(@Nullable Void initData, @NotNull JsonObject payload) {
+    protected void setupInitMessage(@Nullable Void initData, @NotNull JsonObject payload) throws WebviewEditorException {
         AppMapApplicationSettings settings = AppMapApplicationSettingsService.getInstance();
         var apiKey = settings.getApiKey();
         var useAnimation = settings.isUseAnimation();
@@ -312,7 +312,7 @@ public class NavieEditor extends WebviewEditor<Void> {
         });
     }
 
-    protected @Nullable Void createInitData() {
+    protected @Nullable Void createInitData() throws WebviewEditorException {
         return null;
     }
 

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -1,6 +1,15 @@
 appmap.editor.name=AppMap
 appmap.editor.unavailableWarning=Interactive AppMap viewer is not available with the configured JDK. Please switch to the default JetBrains JDK for AppMap to work.
 appmap.editor.loadingFile=Loading AppMap...
+appmap.editor.loadingFile.error.missingPruneCommand=Unable to execute command to prune AppMap {0}. Please verify that the AppMap plugin is up to date and try again.
+appmap.editor.loadingFile.error.prune=Failed to prune AppMap {0}: {1}.
+appmap.editor.loadingFile.error.missingStatsCommand=Unable to execute command for stats of AppMap {0}. Please verify that the AppMap plugin is up to date and try again.
+appmap.editor.loadingFile.error.stats=<html>Failed to load AppMap stats for {0}:<br>{1}.</html>
+appmap.editor.loadingFile.error.content=Error loading AppMap file {0}.
+appmap.editor.loadingFile.error.unknown=<html>Unknown error loading AppMap {0}:<br>{1}.</html>
+appmap.editor.loadingFile.execErrorCause.timeout=Timeout executing {0}
+appmap.editor.loadingFile.execErrorCause.exitCode=Command {0} exited with code {1}
+appmap.editor.loadingFile.execErrorCause.unknown=Unknown error executing {0}
 
 appmap.editor.showSourceFileMissing.title=AppMap
 appmap.editor.showSourceFileMissing.text=File {0} could not be found.
@@ -246,6 +255,7 @@ annotator.quickFixFamily=AppMap
 annotator.openQuickFix.name=Open in AppMap file
 
 webview.loading=Loading webview...
+webview.loading.error.title=AppMap
 
 webview.findingsOverview.title=Findings Overview
 

--- a/plugin-core/src/test/java/appland/files/AppMapFilesTest.java
+++ b/plugin-core/src/test/java/appland/files/AppMapFilesTest.java
@@ -2,6 +2,7 @@ package appland.files;
 
 import appland.cli.AppLandCommandLineService;
 import appland.utils.GsonUtils;
+import appland.webviews.WebviewEditorException;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.intellij.execution.ExecutionException;
@@ -75,7 +76,7 @@ public class AppMapFilesTest extends LightPlatformCodeInsightFixture4TestCase {
     }
 
     @Test
-    public void pruneLargeAppMapFile() {
+    public void pruneLargeAppMapFile() throws WebviewEditorException {
         // file with a size of roughly 2.5mb
         var appMap = myFixture.copyFileToProject("appmap/misago_threads_tests_test_threadslists_AllThreadsListTests_test_noscript_pagination.appmap.json");
         var prunedContent = AppMapFiles.loadAppMapFile(appMap, 10 * 1024 * 1024, 2 * 1024 * 1024, "1mb");
@@ -87,7 +88,7 @@ public class AppMapFilesTest extends LightPlatformCodeInsightFixture4TestCase {
     }
 
     @Test
-    public void pruneGiantAppMapFile() {
+    public void pruneGiantAppMapFile() throws WebviewEditorException {
         // file with a size of roughly 2.5mb
         var appMap = myFixture.copyFileToProject("appmap/misago_threads_tests_test_threadslists_AllThreadsListTests_test_noscript_pagination.appmap.json");
         var prunedContent = AppMapFiles.loadAppMapFile(appMap, 2 * 1024 * 1024, 2 * 1024 * 1024, "1mb");


### PR DESCRIPTION
This PR improves the handling of errors loading a webview editor.
After the message is confirmed by the user, the editor is closed because it's not fully initialized.

Instead of returning null or just logging errors, exceptions are now handled more granular and shown to the user.

To test the timeout, you could change this timeout to 10 seconds: https://github.com/applandinc/appmap-intellij-plugin/blob/444ffce3b9b094ae98db565ec7cf6e1ac89e5fbc/plugin-core/src/main/java/appland/files/AppMapFiles.java#L57

Error message after timeout of the stats command:
<img width="1138" height="751" alt="image" src="https://github.com/user-attachments/assets/1724fe8a-f060-4541-99cc-1c3ccfc10914" />
