### PR TITLE
feat(telemetry): Enhance telemetry with common properties and CLI support

### DIFF
--- a/plugin-core/src/main/java/appland/telemetry/TelemetryProperties.java
+++ b/plugin-core/src/main/java/appland/telemetry/TelemetryProperties.java
@@ -1,0 +1,107 @@
+package appland.telemetry;
+
+import appland.AppMapPlugin;
+import appland.utils.GsonUtils;
+import com.google.gson.annotations.SerializedName;
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.util.SystemInfo;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A utility class for creating and formatting telemetry properties.
+ * It provides static methods to generate the base properties, add prefixes, and serialize them to JSON.
+ */
+public final class TelemetryProperties {
+    public static final @NonNls String EXT_NAME = "extname";
+    public static final @NonNls String EXT_VERSION = "extversion";
+    public static final @NonNls String IDE = "ide";
+    public static final @NonNls String IDE_VERSION = "ideversion";
+    public static final @NonNls String OS = "os";
+    public static final @NonNls String OS_VERSION = "osversion";
+    public static final @NonNls String JVM_VERSION = "jvmversion";
+    public static final @NonNls String PRODUCT = "product";
+    public static final @NonNls String SOURCE = "source";
+    public static final @NonNls String USERNAME = "username";
+
+    private TelemetryProperties() {
+    }
+
+    /**
+     * Creates a new map of telemetry properties.
+     *
+     * @param includeUsername A boolean indicating whether to include the username.
+     * @return A map containing the telemetry properties.
+     */
+    public static @NotNull Map<String, String> create(boolean includeUsername) {
+        var properties = new HashMap<String, String>();
+        properties.put(EXT_NAME, AppMapPlugin.getDescriptor().getPluginId().getIdString());
+        properties.put(EXT_VERSION, AppMapPlugin.getDescriptor().getVersion());
+        properties.put(IDE, ApplicationInfo.getInstance().getFullApplicationName());
+        properties.put(IDE_VERSION, ApplicationInfo.getInstance().getFullVersion());
+        properties.put(OS, SystemInfo.OS_NAME);
+        properties.put(OS_VERSION, SystemInfo.OS_VERSION);
+        properties.put(JVM_VERSION, System.getProperty("java.version"));
+        properties.put(PRODUCT, ApplicationInfo.getInstance().getBuild().getProductCode());
+        properties.put(SOURCE, "JetBrains");
+
+        if (includeUsername) {
+            try {
+                properties.put(USERNAME, System.getProperty("user.name"));
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+        return properties;
+    }
+
+    /**
+     * Returns an unmodifiable map containing the telemetry properties with the "common." prefix
+     * added to each key.
+     *
+     * @param properties The input properties map.
+     * @return An unmodifiable map with prefixed keys.
+     */
+    public static @NotNull Map<String, String> withCommonPrefix(@NotNull Map<String, String> properties) {
+        return Collections.unmodifiableMap(properties.entrySet().stream()
+                .collect(Collectors.toMap(entry -> "common." + entry.getKey(), Map.Entry::getValue)));
+    }
+
+    /**
+     * Returns a JSON representation of a limited set of properties required by the CLI.
+     *
+     * @param properties The input properties map.
+     * @return A JSON string containing the CLI properties.
+     */
+    public static @NotNull String toCliJson(@NotNull Map<String, String> properties) {
+        return GsonUtils.GSON.toJson(new CliProperties(properties));
+    }
+
+    /**
+     * Class to serialize for the CLI env variable.
+     * It's re-serializing from a map to apply the @SerializedName annotations.
+     */
+    private static class CliProperties {
+        @SerializedName(EXT_NAME)
+        final String extName;
+        @SerializedName(EXT_VERSION)
+        final String extVersion;
+        @SerializedName(IDE)
+        final String ide;
+        @SerializedName(IDE_VERSION)
+        final String ideVersion;
+
+        public CliProperties(@NotNull Map<String, String> properties) {
+            // Note these are the only properties we need for the CLI
+            this.extName = properties.get(EXT_NAME);
+            this.extVersion = properties.get(EXT_VERSION);
+            this.ide = properties.get(IDE);
+            this.ideVersion = properties.get(IDE_VERSION);
+        }
+    }
+}

--- a/plugin-core/src/main/java/appland/telemetry/TelemetryService.java
+++ b/plugin-core/src/main/java/appland/telemetry/TelemetryService.java
@@ -87,9 +87,11 @@ public class TelemetryService {
             // If the `backend` is set to `splunk` but the `url` or `token` are missing, telemetry data will not be sent.
             if (SplunkTelemetryUtils.isSplunkTelemetryEnabled(settings)) {
                 LOG.debug("Splunk telemetry is enabled and active. Creating Splunk telemetry reporter.");
+                var properties = TelemetryProperties.create(true);
                 return new SplunkTelemetryReporter(
                         Objects.requireNonNull(telemetry.getUrl()),
-                        Objects.requireNonNull(telemetry.getToken()));
+                        Objects.requireNonNull(telemetry.getToken()),
+                        TelemetryProperties.withCommonPrefix(properties));
             }
 
             LOG.debug("Splunk telemetry is enabled but inactive. Creating no-op telemetry reporter.");
@@ -97,6 +99,7 @@ public class TelemetryService {
         }
 
         LOG.debug("Creating AppInsights telemetry reporter.");
-        return new AppInsightsTelemetryReporter();
+        var properties = TelemetryProperties.create(false);
+        return new AppInsightsTelemetryReporter(TelemetryProperties.withCommonPrefix(properties));
     }
 }

--- a/plugin-core/src/main/java/appland/telemetry/TelemetryStatusEnvProvider.java
+++ b/plugin-core/src/main/java/appland/telemetry/TelemetryStatusEnvProvider.java
@@ -2,15 +2,26 @@ package appland.telemetry;
 
 import appland.cli.AppLandCliEnvProvider;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Pass APPMAP_TELEMETRY_DISABLED in the CLI environment.
+ * Provides telemetry-related environment variables to the CLI environment,
+ * such as APPMAP_TELEMETRY_DISABLED and APPMAP_TELEMETRY_PROPERTIES.
  */
 public final class TelemetryStatusEnvProvider implements AppLandCliEnvProvider {
     @Override
     public Map<String, String> getEnvironment() {
-        // If enabled, pass APPMAP_TELEMETRY_DISABLED=false to the AppMap CLI tools.
-        return Map.of("APPMAP_TELEMETRY_DISABLED", TelemetryService.getInstance().isEnabled() ? "false" : "true");
+        var isEnabled = TelemetryService.getInstance().isEnabled();
+
+        var env = new HashMap<String, String>();
+        env.put("APPMAP_TELEMETRY_DISABLED", isEnabled ? "false" : "true");
+
+        if (isEnabled) {
+            var properties = TelemetryProperties.create(false);
+            env.put("APPMAP_TELEMETRY_PROPERTIES", TelemetryProperties.toCliJson(properties));
+        }
+
+        return env;
     }
 }

--- a/plugin-core/src/main/java/appland/telemetry/appinsights/BaseData.java
+++ b/plugin-core/src/main/java/appland/telemetry/appinsights/BaseData.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
+import java.util.Map;
 
 @SuppressWarnings("unused")
 class BaseData {
@@ -21,19 +22,26 @@ class BaseData {
     @Nullable HashMap<String, Double> metrics;
 
     public BaseData(@NotNull String name) {
-        this(name, null);
+        this(name, null, null);
     }
 
     /**
      * Constructor to copy the properties and metrics from an existing TelemetryEvent.
      *
      * @param name  The name of the event.
+     * @param commonProperties Common properties to include.
      * @param event The event to copy.
      */
-    public BaseData(@NotNull String name, @Nullable TelemetryEvent event) {
+    public BaseData(@NotNull String name, @Nullable Map<String, String> commonProperties, @Nullable TelemetryEvent event) {
         this.name = name;
-        this.properties = event != null ? new HashMap<>(event.getProperties()) : null;
-        this.metrics = event != null ? new HashMap<>(event.getMetrics()) : null;
+        this.properties = new HashMap<>();
+        if (commonProperties != null) {
+            this.properties.putAll(commonProperties);
+        }
+        if (event != null) {
+            this.properties.putAll(event.getProperties());
+            this.metrics = new HashMap<>(event.getMetrics());
+        }
     }
 
     public @NotNull BaseData property(String key, String value) {

--- a/plugin-core/src/main/java/appland/telemetry/splunk/SplunkTelemetryEvent.java
+++ b/plugin-core/src/main/java/appland/telemetry/splunk/SplunkTelemetryEvent.java
@@ -12,20 +12,12 @@ import java.util.Map;
  */
 @Value
 class SplunkTelemetryEvent {
-    @SerializedName("extensionId")
-    @NotNull
-    String extensionId;
-
-    @SerializedName("extensionVersion")
-    @NotNull
-    String extensionVersion;
-
-    @SerializedName("eventName")
+    @SerializedName("name")
     @Nullable
-    String eventName;
+    String name;
 
     @SerializedName("properties")
-    @Nullable
+    @NotNull
     Map<String, String> properties;
 
     @SerializedName("measurements")

--- a/plugin-core/src/test/java/appland/telemetry/TelemetryPropertiesTest.java
+++ b/plugin-core/src/test/java/appland/telemetry/TelemetryPropertiesTest.java
@@ -1,0 +1,59 @@
+package appland.telemetry;
+
+import appland.AppMapBaseTest;
+import appland.utils.GsonUtils;
+import com.google.gson.reflect.TypeToken;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class TelemetryPropertiesTest extends AppMapBaseTest {
+    @Test
+    public void testCreateProperties() {
+        var properties = TelemetryProperties.create(false);
+        assertCommonProperties(properties);
+        assertNull(properties.get(TelemetryProperties.USERNAME));
+
+        var propertiesWithUsername = TelemetryProperties.create(true);
+        assertCommonProperties(propertiesWithUsername);
+        assertNotNull(propertiesWithUsername.get(TelemetryProperties.USERNAME));
+    }
+
+    @Test
+    public void testToCliJson() {
+        var properties = TelemetryProperties.create(false);
+        var json = TelemetryProperties.toCliJson(properties);
+
+        Map<String, String> deserialized = GsonUtils.GSON.fromJson(json, new TypeToken<Map<String, String>>() {
+        }.getType());
+
+        assertEquals(properties.get(TelemetryProperties.EXT_NAME), deserialized.get(TelemetryProperties.EXT_NAME));
+        assertEquals(properties.get(TelemetryProperties.EXT_VERSION), deserialized.get(TelemetryProperties.EXT_VERSION));
+        assertEquals(properties.get(TelemetryProperties.IDE), deserialized.get(TelemetryProperties.IDE));
+        assertEquals(properties.get(TelemetryProperties.IDE_VERSION), deserialized.get(TelemetryProperties.IDE_VERSION));
+    }
+
+    @Test
+    public void testWithCommonPrefix() {
+        var properties = TelemetryProperties.create(false);
+        var prefixed = TelemetryProperties.withCommonPrefix(properties);
+
+        for (var entry : properties.entrySet()) {
+            assertEquals(entry.getValue(), prefixed.get("common." + entry.getKey()));
+        }
+
+        assertThrows(UnsupportedOperationException.class, () -> prefixed.put("a", "b"));
+    }
+
+    private void assertCommonProperties(Map<String, String> properties) {
+        assertNotNull(properties.get(TelemetryProperties.EXT_NAME));
+        assertNotNull(properties.get(TelemetryProperties.EXT_VERSION));
+        assertNotNull(properties.get(TelemetryProperties.IDE));
+        assertNotNull(properties.get(TelemetryProperties.IDE_VERSION));
+        assertNotNull(properties.get(TelemetryProperties.OS));
+        assertNotNull(properties.get(TelemetryProperties.OS_VERSION));
+        assertNotNull(properties.get(TelemetryProperties.JVM_VERSION));
+        assertNotNull(properties.get(TelemetryProperties.PRODUCT));
+        assertNotNull(properties.get(TelemetryProperties.SOURCE));
+    }
+}

--- a/plugin-core/src/test/java/appland/telemetry/TelemetryStatusEnvProviderTest.java
+++ b/plugin-core/src/test/java/appland/telemetry/TelemetryStatusEnvProviderTest.java
@@ -1,0 +1,25 @@
+package appland.telemetry;
+
+import appland.AppMapBaseTest;
+import appland.settings.AppMapApplicationSettingsService;
+import org.junit.Test;
+
+public class TelemetryStatusEnvProviderTest extends AppMapBaseTest {
+    @Test
+    public void testTelemetryDisabled() {
+        AppMapApplicationSettingsService.getInstance().setEnableTelemetry(false);
+
+        var env = new TelemetryStatusEnvProvider().getEnvironment();
+        assertEquals("true", env.get("APPMAP_TELEMETRY_DISABLED"));
+        assertNull(env.get("APPMAP_TELEMETRY_PROPERTIES"));
+    }
+
+    @Test
+    public void testTelemetryEnabled() {
+        AppMapApplicationSettingsService.getInstance().setEnableTelemetry(true);
+
+        var env = new TelemetryStatusEnvProvider().getEnvironment();
+        assertEquals("false", env.get("APPMAP_TELEMETRY_DISABLED"));
+        assertNotNull(env.get("APPMAP_TELEMETRY_PROPERTIES"));
+    }
+}

--- a/plugin-core/src/test/java/appland/telemetry/appinsights/AppInsightsTelemetryReporterTest.java
+++ b/plugin-core/src/test/java/appland/telemetry/appinsights/AppInsightsTelemetryReporterTest.java
@@ -13,6 +13,8 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonPathBody.jsonPath;
 
+import java.util.Map;
+
 public class AppInsightsTelemetryReporterTest extends AppMapBaseTest {
     @Rule
     public MockServerRule mockServerRule = new MockServerRule(this, false);
@@ -30,7 +32,8 @@ public class AppInsightsTelemetryReporterTest extends AppMapBaseTest {
                 .when(request().withMethod("POST").withPath("/v2/track"))
                 .respond(response().withStatusCode(200));
 
-        new AppInsightsTelemetryReporter("http://127.0.0.1:" + mockServerRule.getPort()).track(
+        var commonProperties = Map.of("common.extname", "appmap-intellij-plugin");
+        new AppInsightsTelemetryReporter("http://127.0.0.1:" + mockServerRule.getPort(), commonProperties).track(
                 new TelemetryEvent("my-event")
                         .withProperty("property1", "propertyValue1")
                         .withProperty("property2", "propertyValue2")
@@ -43,13 +46,7 @@ public class AppInsightsTelemetryReporterTest extends AppMapBaseTest {
 
         // common properties
         mockServerRule.getClient()
-                .verify(request().withBody(jsonPath("$.data.baseData.properties[?(@.'common.os' != '')]")))
-                .verify(request().withBody(jsonPath("$.data.baseData.properties[?(@.'common.platformversion' != '')]")))
-                .verify(request().withBody(jsonPath("$.data.baseData.properties[?(@.'common.jvmversion' != '')]")))
-                .verify(request().withBody(jsonPath("$.data.baseData.properties[?(@.'common.extversion' != '')]")))
-                .verify(request().withBody(jsonPath("$.data.baseData.properties[?(@.'common.intellijversion' != '')]")))
-                .verify(request().withBody(jsonPath("$.data.baseData.properties[?(@.'common.product' != '')]")))
-                .verify(request().withBody(jsonPath("$.data.baseData.properties[?(@.'common.source' != '')]")));
+                .verify(request().withBody(jsonPath("$.data.baseData.properties[?(@.'common.extname' != '')]")));
 
         // properties
         mockServerRule.getClient()


### PR DESCRIPTION
This commit revamps the telemetry system to include a standardized set of common properties with every event, aligning the implementation with the VS Code extension.

Key changes include:
- A new `TelemetryProperties` class centralizes the collection of common data such as IDE version, OS, and extension details.
- Both `SplunkTelemetryReporter` and `AppInsightsTelemetryReporter` are refactored to consume and correctly prefix these common properties. The `username` property is now exclusively sent to Splunk.
- The `SplunkTelemetryEvent` format is updated to match the new specification.
- The `TelemetryStatusEnvProvider` now exports these common properties as an `APPMAP_TELEMETRY_PROPERTIES` environment variable for CLI tools (see https://github.com/getappmap/appmap-js/pull/2339 )
- Corresponding unit tests have been added and updated to ensure the new functionality is correct and robust.

VS Code companion: https://github.com/getappmap/vscode-appland/pull/1103