### PR TITLE
Free up disk space on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,26 @@ jobs:
         runs-on: ${{ matrix.os }}-latest
         timeout-minutes: 45
         steps:
+            # https://github.com/actions/runner-images/issues/2840#issuecomment-2272410832
+            - name: Free up disk space (Linux)
+              if: runner.os == 'Linux'
+              run: |
+                  sudo rm -rf \
+                    "$AGENT_TOOLSDIRECTORY" \
+                    /opt/google/chrome \
+                    /opt/microsoft/msedge \
+                    /opt/microsoft/powershell \
+                    /opt/pipx \
+                    /usr/lib/mono \
+                    /usr/local/julia* \
+                    /usr/local/lib/android \
+                    /usr/local/lib/node_modules \
+                    /usr/local/share/chromium \
+                    /usr/local/share/powershell \
+                    /usr/share/dotnet \
+                    /usr/share/swift
+                  df -h /
+
             - name: Fetch Sources
               uses: actions/checkout@v5
 
@@ -71,6 +91,26 @@ jobs:
         needs: [test]
         timeout-minutes: 45
         steps:
+            # https://github.com/actions/runner-images/issues/2840#issuecomment-2272410832
+            - name: Free up disk space (Linux)
+              if: runner.os == 'Linux'
+              run: |
+                  sudo rm -rf \
+                    "$AGENT_TOOLSDIRECTORY" \
+                    /opt/google/chrome \
+                    /opt/microsoft/msedge \
+                    /opt/microsoft/powershell \
+                    /opt/pipx \
+                    /usr/lib/mono \
+                    /usr/local/julia* \
+                    /usr/local/lib/android \
+                    /usr/local/lib/node_modules \
+                    /usr/local/share/chromium \
+                    /usr/local/share/powershell \
+                    /usr/share/dotnet \
+                    /usr/share/swift
+                  df -h /
+
             - name: Fetch Sources
               uses: actions/checkout@v5
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,26 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         steps:
+            # https://github.com/actions/runner-images/issues/2840#issuecomment-2272410832
+            - name: Free up disk space (Linux)
+              if: runner.os == 'Linux'
+              run: |
+                  sudo rm -rf \
+                    "$AGENT_TOOLSDIRECTORY" \
+                    /opt/google/chrome \
+                    /opt/microsoft/msedge \
+                    /opt/microsoft/powershell \
+                    /opt/pipx \
+                    /usr/lib/mono \
+                    /usr/local/julia* \
+                    /usr/local/lib/android \
+                    /usr/local/lib/node_modules \
+                    /usr/local/share/chromium \
+                    /usr/local/share/powershell \
+                    /usr/share/dotnet \
+                    /usr/share/swift
+                  df -h /
+
             - name: Fetch Sources
               uses: actions/checkout@v5
               with:


### PR DESCRIPTION
Deploy https://github.com/getappmap/appmap-intellij-plugin/actions/runs/19270700874 ran out of disk space
This PR attempts to fix this problem.