### PR TITLE
Exception "IncorrectOperationException" after closing an AppMap editor

### DIFF
--- a/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
+++ b/plugin-core/src/main/java/appland/webviews/WebviewEditor.java
@@ -43,6 +43,7 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
     private static final Logger LOG = Logger.getInstance(WebviewEditor.class);
 
     protected final @NotNull Project project;
+    protected final AtomicBoolean isDisposed = new AtomicBoolean(false);
     protected final @NotNull AppMapWebview webview;
     protected final @NotNull VirtualFile file;
     private final @NotNull Set<String> supportedMessages;
@@ -132,7 +133,7 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
 
     @Override
     public boolean isValid() {
-        return true;
+        return !isDisposed.get();
     }
 
     @Override
@@ -150,6 +151,7 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
 
     @Override
     public void dispose() {
+        isDisposed.set(true);
     }
 
     @Override
@@ -238,7 +240,7 @@ public abstract class WebviewEditor<T> extends UserDataHolderBase implements Fil
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
                 if (!isValid()) {
-                    // editor was closed before the init completed
+                    // The editor was closed before the init completed
                     return;
                 }
 

--- a/plugin-core/src/test/java/appland/webviews/appMap/AppMapFileEditorTest.java
+++ b/plugin-core/src/test/java/appland/webviews/appMap/AppMapFileEditorTest.java
@@ -1,0 +1,21 @@
+package appland.webviews.appMap;
+
+import appland.AppMapBaseTest;
+import com.intellij.openapi.util.Disposer;
+import org.junit.Assume;
+import org.junit.Test;
+
+public class AppMapFileEditorTest extends AppMapBaseTest {
+    @Test
+    public void disposal() {
+        // JCEF is incompatible with headless environments, e.g. CI like GitHub Action
+        Assume.assumeTrue(System.getenv("CI") == null);
+
+        var file = myFixture.configureByText("appmap.json", "{}");
+        var editor = new AppMapFileEditor(getProject(), file.getVirtualFile());
+        assertTrue(editor.isValid());
+
+        Disposer.dispose(editor);
+        assertFalse("isValid must evaluate state of disposal", editor.isValid());
+    }
+}


### PR DESCRIPTION
Closes https://github.com/getappmap/appmap-intellij-plugin/issues/925

The AppMap editors did not return false in `isValid` after disposal.