### PR TITLE
ci: Automatically publish the plugin to JB Marketplace on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ on:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        environment: Marketplace Deployment
         if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'schedule') }}
         steps:
             - name: Fetch Sources
@@ -56,4 +57,5 @@ jobs:
                   GIT_AUTHOR_EMAIL: release@app.land
                   GIT_COMMITTER_NAME: appland-release
                   GIT_COMMITTER_EMAIL: release@app.land
+                  JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
               run: semantic-release --debug

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -54,7 +54,7 @@ plugins:
     - CHANGELOG.md
     - gradle.properties
 - - '@semantic-release/exec'
-  - publishCmd: ./gradlew clean buildPlugin -x test -x testAgent
+  - publishCmd: ./gradlew clean buildPlugin publishPlugin -x test -x testAgent
 - - '@semantic-release/github'
   - assets:
     - build/distributions/intellij-appmap-*.zip

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -347,6 +347,10 @@ project(":") {
                 )
             )
         }
+
+        publishing {
+            token.set(System.getenv("JETBRAINS_MARKETPLACE_TOKEN"))
+        }
     }
 
 


### PR DESCRIPTION
Note I've already added the `Marketplace Deployment` environment containing the token. The environment is configured such that it will require a manual approval.