### PR TITLE
fix: support Java 25 when executing with the AppMap agent

### DIFF
--- a/plugin-java/src/main/java/appland/execution/AppMapJvmExecutor.java
+++ b/plugin-java/src/main/java/appland/execution/AppMapJvmExecutor.java
@@ -26,7 +26,7 @@ import javax.swing.*;
 public class AppMapJvmExecutor extends Executor {
     public static final String EXECUTOR_ID = "AppMap";
     // latest version of Java, which is supported by the AppMap JVM agent
-    private static final int LATEST_SUPPORTED_JAVA_VERSION = 21;
+    private static final int LATEST_SUPPORTED_JAVA_VERSION = 25;
 
     public static @NotNull Executor getInstance() {
         var executor = ExecutorRegistry.getInstance().getExecutorById(EXECUTOR_ID);


### PR DESCRIPTION
This increments the supported Java version to 25. Now, the warning about incompatibility will be shown for Java 26 and later.

I tried executing this with a fresh, very simple Gradle project and Java 25. 
The directory had a Git repository, but it was not yet pushed to a server.

@dividedmind 
There is a warning, which may need attention in the AppMap agent:
```
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.appland.shade.net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction (file:/home/jansorg/.appmap/lib/java/appmap-agent-1.30.0.jar)
WARNING: Please consider reporting this to the maintainers of class com.appland.shade.net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```

Running this with AppMap did not create an AppMap. Should it have created an AppMap for this test program?
```java
package org.example;

public class Main {
    public static void main(String[] args) {
        myMethod();
    }

    private static void myMethod() {
        myOtherMethod();
    }

    private static void myOtherMethod() {
        var other = new OtherClass();
        other.myOtherMethod();
    }
}

class OtherClass {
    public OtherClass() {
    }

    void myOtherMethod() {
        System.out.println("Hello world!");
    }
}
```


```
/home/jansorg/.jdks/openjdk-25.0.2/bin/java -Dappmap.config.file=/home/jansorg/IdeaProjects/java25-test/appmap.yml -javaagent:/home/jansorg/.appmap/lib/java/appmap.jar -javaagent:/home/jansorg/.intellijPlatform/ides/IC-2024.1/lib/idea_rt.jar=37195:/home/jansorg/.intellijPlatform/ides/IC-2024.1/bin -Dfile.encoding=UTF-8 -classpath /home/jansorg/IdeaProjects/java25-test/build/classes/java/main org.example.Main
AppMap agent version 1.30.0 starting
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.appland.shade.net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction (file:/home/jansorg/.appmap/lib/java/appmap-agent-1.30.0.jar)
WARNING: Please consider reporting this to the maintainers of class com.appland.shade.net.bytebuddy.dynamic.loading.ClassInjector$UsingUnsafe$Dispatcher$CreationAction
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
Hello world!
```