### PR TITLE
ci: publish to marketplace before committing the version bump

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -49,12 +49,17 @@ plugins:
         hasChanged: true
         numMatches: 1
         numReplacements: 1
+# exec uses prepareCmd (not publishCmd) and is ordered before @semantic-release/git
+# intentionally: semantic-release pushes commits+tags after all prepare plugins but
+# before any publish plugins, so publishCmd would push the version bump commit even
+# if the marketplace upload fails. With prepareCmd here, a failed upload aborts
+# prepare before git ever commits, leaving main untouched.
+- - '@semantic-release/exec'
+  - prepareCmd: ./gradlew clean buildPlugin publishPlugin -x test -x testAgent
 - - '@semantic-release/git'
   - assets:
     - CHANGELOG.md
     - gradle.properties
-- - '@semantic-release/exec'
-  - publishCmd: ./gradlew clean buildPlugin publishPlugin -x test -x testAgent
 - - '@semantic-release/github'
   - assets:
     - build/distributions/intellij-appmap-*.zip


### PR DESCRIPTION
semantic-release pushes git commits/tags after all prepare plugins but before any publish plugins, so a failed publishPlugin left a dangling version bump commit on main (as happened with the 0.83.1 release when the marketplace agreement was unaccepted).

Fix by using prepareCmd instead of publishCmd and ordering @semantic-release/exec before @semantic-release/git: if the upload fails, @semantic-release/git never runs and main stays clean.