### PR TITLE
ci: Split release into two stages; publish triggered by tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,12 +85,20 @@ jobs:
         steps:
             - name: Fetch Sources
               uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
 
             - name: Setup Java
               uses: actions/setup-java@v5
               with:
                   distribution: jetbrains
                   java-version: ${{ env.JAVA_VERSION }}
+
+            - name: Set development version
+              shell: bash
+              run: |
+                  VERSION=$(git describe --tags --always | sed 's/^v//')
+                  sed -i "s/^pluginVersion=.*/pluginVersion=$VERSION/" gradle.properties
 
             - name: Verify Plugin Structure
               shell: bash
@@ -100,19 +108,9 @@ jobs:
               shell: bash
               run: ./gradlew verifyPlugin
 
-            - name: Prepare plugin distribution upload
-              id: artifact
-              run: |
-                  cd "${{ github.workspace }}/build/distributions"
-
-                  FILENAME="$(ls *.zip)"
-                  unzip -d content "$FILENAME"
-
-                  OUTPUT_FILENAME="${FILENAME/.zip/}-build${GITHUB_RUN_NUMBER}.${GITHUB_SHA::6}"
-                  echo "filename=${OUTPUT_FILENAME}" >> $GITHUB_OUTPUT
-
             - name: Upload plugin distribution
               uses: actions/upload-artifact@v7
               with:
-                  name: ${{ steps.artifact.outputs.filename }}
-                  path: ${{ github.workspace }}/build/distributions/content/**/*
+                  name: plugin-distribution
+                  path: build/distributions/intellij-appmap-*.zip
+                  archive: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
               run: df -h
 
             - name: Fetch Sources
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup Java
               uses: actions/setup-java@v5
@@ -57,7 +57,7 @@ jobs:
               run: ./gradlew -PplatformVersion=${{ matrix.platform_version }} check
 
             - name: Upload Test Reports
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               if: always()
               with:
                   name: test-reports-${{ matrix.os }}-${{ matrix.platform_version }}
@@ -66,7 +66,7 @@ jobs:
                       **/build/reports/
 
             - name: Save AppMaps
-              uses: actions/cache/save@v4
+              uses: actions/cache/save@v5
               if: runner.os == 'Linux' && matrix.platform_version == '251'
               with:
                   path: ./tmp/appmap
@@ -84,7 +84,7 @@ jobs:
         timeout-minutes: 45
         steps:
             - name: Fetch Sources
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup Java
               uses: actions/setup-java@v5
@@ -112,7 +112,7 @@ jobs:
                   echo "filename=${OUTPUT_FILENAME}" >> $GITHUB_OUTPUT
 
             - name: Upload plugin distribution
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: ${{ steps.artifact.outputs.filename }}
                   path: ${{ github.workspace }}/build/distributions/content/**/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
-name: Deploy
+name: Release
 on:
     workflow_dispatch:
         inputs:
             confirm:
-                description: "Acknowledge that verification is NOT performed before deploy"
+                description: "Acknowledge that verification is NOT performed before release"
                 required: true
                 type: boolean
     workflow_run:
@@ -12,13 +12,19 @@ on:
         branches: [main]
 
 jobs:
-    deploy:
+    release:
         runs-on: ubuntu-latest
-        environment: Marketplace Deployment
-        if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'schedule') }}
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.confirm) || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'schedule') }}
         steps:
+            - name: Generate GitHub App Token
+              uses: actions/create-github-app-token@v1
+              id: app-token
+              with:
+                  app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+                  private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
             - name: Fetch Sources
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   persist-credentials: false
 
@@ -30,15 +36,13 @@ jobs:
 
             - name: Setup Gradle
               uses: gradle/actions/setup-gradle@v5
-              with:
-                  cache-disabled: true
 
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
                   node-version: 20
 
-            - name: "Install Dependencies"
+            - name: Install Dependencies
               shell: bash
               run: |
                   npm i -g \
@@ -49,13 +53,12 @@ jobs:
                     @google/semantic-release-replace-plugin@1 \
                     conventional-changelog-conventionalcommits@7.0.2
 
-            - name: "Deploy"
+            - name: Release
               shell: bash
               env:
-                  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+                  GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
                   GIT_AUTHOR_NAME: appland-release
                   GIT_AUTHOR_EMAIL: release@app.land
                   GIT_COMMITTER_NAME: appland-release
                   GIT_COMMITTER_EMAIL: release@app.land
-                  JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
               run: semantic-release --debug

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish
+on:
+    push:
+        tags:
+            - 'v*'
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Tag to publish (e.g. v0.83.1)"
+                required: true
+                type: string
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        environment: Marketplace Deployment
+        steps:
+            - name: Fetch Sources
+              uses: actions/checkout@v6
+              with:
+                  # Force refs/tags/ prefix so that a branch name or non-existent value
+                  # causes checkout to fail rather than silently publishing from wrong code.
+                  ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+
+            - name: Setup Java
+              uses: actions/setup-java@v5
+              with:
+                  distribution: jetbrains
+                  java-version: 21
+
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v5
+
+            - name: Publish Plugin
+              shell: bash
+              env:
+                  JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+              run: ./gradlew clean buildPlugin publishPlugin -x test -x testAgent

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -49,13 +49,8 @@ plugins:
         hasChanged: true
         numMatches: 1
         numReplacements: 1
-# exec uses prepareCmd (not publishCmd) and is ordered before @semantic-release/git
-# intentionally: semantic-release pushes commits+tags after all prepare plugins but
-# before any publish plugins, so publishCmd would push the version bump commit even
-# if the marketplace upload fails. With prepareCmd here, a failed upload aborts
-# prepare before git ever commits, leaving main untouched.
 - - '@semantic-release/exec'
-  - prepareCmd: ./gradlew clean buildPlugin publishPlugin -x test -x testAgent
+  - prepareCmd: ./gradlew clean buildPlugin -x test -x testAgent
 - - '@semantic-release/git'
   - assets:
     - CHANGELOG.md

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -314,8 +314,8 @@ project(":") {
 
             changeNotes.set(provider {
                 val item = when {
-                    pluginVersionString.endsWith("-SNAPSHOT") -> changelog.getUnreleased()
-                    else -> changelog.get(pluginVersionString)
+                    pluginVersionString.matches(Regex("\\d+\\.\\d+\\.\\d+")) -> changelog.get(pluginVersionString)
+                    else -> changelog.getLatest()
                 }
                 changelog.renderItem(item.withHeader(false), Changelog.OutputType.HTML)
             })


### PR DESCRIPTION
Previously, the deploy workflow ran on every successful build of main, hitting the Marketplace Deployment approval gate even when no release was needed. A failed publishPlugin also left a dangling version bump commit on main (as in the 0.83.1 incident).

Now:
- deploy.yml (release stage): runs semantic-release on CI pass, no approval gate; builds the plugin ZIP before committing so a build failure aborts before any git state is touched; uses the releasebot GitHub App instead of a PAT.
- publish.yml (new): triggered by v* tag push, carries the Marketplace Deployment approval gate; also has workflow_dispatch with a tag input for manual re-runs without git surgery.
- Gradle cache enabled in both workflows.

Additionally:
- github actions versions were bumped to the most recent ones, getting rid of deprecation warnings;
- the dev build artifact archive is now tagged with `git describe`-derived version both in the package name and the metadata; the archive upload process is also simplified.