### PR TITLE
Use manifests to download tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,13 @@ jobs:
               with:
                   cache-disabled: true
 
+            - name: Cache AppMap test binaries
+              uses: actions/cache@v5
+              with:
+                  path: ~/.cache/appmap-test
+                  key: appmap-test-binaries-${{ runner.os }}-${{ github.run_id }}
+                  restore-keys: appmap-test-binaries-${{ runner.os }}-
+
             # https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
             - name: Show GitHub Actions rate limit
               shell: bash
@@ -54,7 +61,7 @@ jobs:
 
             - name: Run Linters and Test
               shell: bash
-              run: ./gradlew -PplatformVersion=${{ matrix.platform_version }} check
+              run: ./gradlew -PplatformVersion=${{ matrix.platform_version }} -PincludeNetworkTests check
 
             - name: Upload Test Reports
               uses: actions/upload-artifact@v7

--- a/appland-webview/package.json
+++ b/appland-webview/package.json
@@ -26,7 +26,8 @@
     "vue-template-compiler": "^2.7"
   },
   "resolutions": {
-    "@appland/rpc": "1.19.0"
+    "@appland/rpc": "1.19.0",
+    "esbuild": "0.28.1"
   },
   "packageManager": "yarn@4.13.0"
 }

--- a/appland-webview/yarn.lock
+++ b/appland-webview/yarn.lock
@@ -191,184 +191,184 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/aix-ppc64@npm:0.27.4"
+"@esbuild/aix-ppc64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/aix-ppc64@npm:0.28.1"
   conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/android-arm64@npm:0.27.4"
+"@esbuild/android-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-arm64@npm:0.28.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/android-arm@npm:0.27.4"
+"@esbuild/android-arm@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-arm@npm:0.28.1"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/android-x64@npm:0.27.4"
+"@esbuild/android-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-x64@npm:0.28.1"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/darwin-arm64@npm:0.27.4"
+"@esbuild/darwin-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/darwin-arm64@npm:0.28.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/darwin-x64@npm:0.27.4"
+"@esbuild/darwin-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/darwin-x64@npm:0.28.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/freebsd-arm64@npm:0.27.4"
+"@esbuild/freebsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.28.1"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/freebsd-x64@npm:0.27.4"
+"@esbuild/freebsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/freebsd-x64@npm:0.28.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-arm64@npm:0.27.4"
+"@esbuild/linux-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-arm64@npm:0.28.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-arm@npm:0.27.4"
+"@esbuild/linux-arm@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-arm@npm:0.28.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-ia32@npm:0.27.4"
+"@esbuild/linux-ia32@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-ia32@npm:0.28.1"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-loong64@npm:0.27.4"
+"@esbuild/linux-loong64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-loong64@npm:0.28.1"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-mips64el@npm:0.27.4"
+"@esbuild/linux-mips64el@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-mips64el@npm:0.28.1"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-ppc64@npm:0.27.4"
+"@esbuild/linux-ppc64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-ppc64@npm:0.28.1"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-riscv64@npm:0.27.4"
+"@esbuild/linux-riscv64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-riscv64@npm:0.28.1"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-s390x@npm:0.27.4"
+"@esbuild/linux-s390x@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-s390x@npm:0.28.1"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-x64@npm:0.27.4"
+"@esbuild/linux-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-x64@npm:0.28.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/netbsd-arm64@npm:0.27.4"
+"@esbuild/netbsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/netbsd-arm64@npm:0.28.1"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/netbsd-x64@npm:0.27.4"
+"@esbuild/netbsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/netbsd-x64@npm:0.28.1"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/openbsd-arm64@npm:0.27.4"
+"@esbuild/openbsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.28.1"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/openbsd-x64@npm:0.27.4"
+"@esbuild/openbsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openbsd-x64@npm:0.28.1"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openharmony-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/openharmony-arm64@npm:0.27.4"
+"@esbuild/openharmony-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openharmony-arm64@npm:0.28.1"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/sunos-x64@npm:0.27.4"
+"@esbuild/sunos-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/sunos-x64@npm:0.28.1"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/win32-arm64@npm:0.27.4"
+"@esbuild/win32-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-arm64@npm:0.28.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/win32-ia32@npm:0.27.4"
+"@esbuild/win32-ia32@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-ia32@npm:0.28.1"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/win32-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/win32-x64@npm:0.27.4"
+"@esbuild/win32-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-x64@npm:0.28.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1707,36 +1707,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.27.0":
-  version: 0.27.4
-  resolution: "esbuild@npm:0.27.4"
+"esbuild@npm:0.28.1":
+  version: 0.28.1
+  resolution: "esbuild@npm:0.28.1"
   dependencies:
-    "@esbuild/aix-ppc64": "npm:0.27.4"
-    "@esbuild/android-arm": "npm:0.27.4"
-    "@esbuild/android-arm64": "npm:0.27.4"
-    "@esbuild/android-x64": "npm:0.27.4"
-    "@esbuild/darwin-arm64": "npm:0.27.4"
-    "@esbuild/darwin-x64": "npm:0.27.4"
-    "@esbuild/freebsd-arm64": "npm:0.27.4"
-    "@esbuild/freebsd-x64": "npm:0.27.4"
-    "@esbuild/linux-arm": "npm:0.27.4"
-    "@esbuild/linux-arm64": "npm:0.27.4"
-    "@esbuild/linux-ia32": "npm:0.27.4"
-    "@esbuild/linux-loong64": "npm:0.27.4"
-    "@esbuild/linux-mips64el": "npm:0.27.4"
-    "@esbuild/linux-ppc64": "npm:0.27.4"
-    "@esbuild/linux-riscv64": "npm:0.27.4"
-    "@esbuild/linux-s390x": "npm:0.27.4"
-    "@esbuild/linux-x64": "npm:0.27.4"
-    "@esbuild/netbsd-arm64": "npm:0.27.4"
-    "@esbuild/netbsd-x64": "npm:0.27.4"
-    "@esbuild/openbsd-arm64": "npm:0.27.4"
-    "@esbuild/openbsd-x64": "npm:0.27.4"
-    "@esbuild/openharmony-arm64": "npm:0.27.4"
-    "@esbuild/sunos-x64": "npm:0.27.4"
-    "@esbuild/win32-arm64": "npm:0.27.4"
-    "@esbuild/win32-ia32": "npm:0.27.4"
-    "@esbuild/win32-x64": "npm:0.27.4"
+    "@esbuild/aix-ppc64": "npm:0.28.1"
+    "@esbuild/android-arm": "npm:0.28.1"
+    "@esbuild/android-arm64": "npm:0.28.1"
+    "@esbuild/android-x64": "npm:0.28.1"
+    "@esbuild/darwin-arm64": "npm:0.28.1"
+    "@esbuild/darwin-x64": "npm:0.28.1"
+    "@esbuild/freebsd-arm64": "npm:0.28.1"
+    "@esbuild/freebsd-x64": "npm:0.28.1"
+    "@esbuild/linux-arm": "npm:0.28.1"
+    "@esbuild/linux-arm64": "npm:0.28.1"
+    "@esbuild/linux-ia32": "npm:0.28.1"
+    "@esbuild/linux-loong64": "npm:0.28.1"
+    "@esbuild/linux-mips64el": "npm:0.28.1"
+    "@esbuild/linux-ppc64": "npm:0.28.1"
+    "@esbuild/linux-riscv64": "npm:0.28.1"
+    "@esbuild/linux-s390x": "npm:0.28.1"
+    "@esbuild/linux-x64": "npm:0.28.1"
+    "@esbuild/netbsd-arm64": "npm:0.28.1"
+    "@esbuild/netbsd-x64": "npm:0.28.1"
+    "@esbuild/openbsd-arm64": "npm:0.28.1"
+    "@esbuild/openbsd-x64": "npm:0.28.1"
+    "@esbuild/openharmony-arm64": "npm:0.28.1"
+    "@esbuild/sunos-x64": "npm:0.28.1"
+    "@esbuild/win32-arm64": "npm:0.28.1"
+    "@esbuild/win32-ia32": "npm:0.28.1"
+    "@esbuild/win32-x64": "npm:0.28.1"
   dependenciesMeta:
     "@esbuild/aix-ppc64":
       optional: true
@@ -1792,7 +1792,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 10c0/2a1c2bcccda279f2afd72a7f8259860cb4483b32453d17878e1ecb4ac416b9e7c1001e7aa0a25ba4c29c1e250a3ceaae5d8bb72a119815bc8db4e9b5f5321490
+  checksum: 10c0/29cd456a79ce35ac2c7e05fe871330416b2c395c045d849653f843e51378d6e0d6e774d6dcd01b35f4e83238a29bf8decd04fcd34b3780c589a250b21e5f92bb
   languageName: node
   linkType: hard
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -228,6 +228,12 @@ allprojects {
             // all our tests need the jar, even if the agent is disabled
             dependsOn(":downloadAppMapAgent")
 
+            if (!project.hasProperty("includeNetworkTests")) {
+                useJUnit {
+                    excludeCategories("appland.RequiresNetwork")
+                }
+            }
+
             systemProperty("idea.test.execution.policy", "appland.AppLandTestExecutionPolicy")
             systemProperty("appland.testDataPath", rootProject.rootDir.resolve("src/test/data").path)
             if (isCI && githubToken != null) {

--- a/plugin-core/src/main/java/appland/actions/PluginStatus.java
+++ b/plugin-core/src/main/java/appland/actions/PluginStatus.java
@@ -112,15 +112,18 @@ public class PluginStatus extends AnAction implements DumbAware {
         String latestVersionText = String.format("Latest version: %s",
                 latestVersion == null ? "Failed to check for the latest version" : latestVersion);
 
-        var downloadedVersion = LocalAssetRepository.getInstalledVersion(type);
         var downloadPath = CliTools.getBinaryPath(type);
 
         String localVersionText = "Your version: ";
-        if (downloadedVersion == null || downloadPath == null) {
+        if (downloadPath == null) {
             localVersionText += "*unavailable*";
         } else {
-            localVersionText += downloadedVersion;
-            localVersionText += String.format("\n\nLocation: %s", downloadPath);
+            // Best-effort version: symlink target carries version in its filename; bundled path also has it.
+            var version = LocalAssetRepository.getInstalledVersion(type);
+            var resolved = LocalAssetRepository.resolveForVersionComparison(downloadPath);
+            if (version == null && resolved != null) version = LocalAssetRepository.versionFromPath(resolved);
+            localVersionText += version != null ? version : "*unknown*";
+            localVersionText += String.format("\n\nLocation: %s", resolved != null ? resolved : downloadPath);
         }
 
         return getBinaryReportHeader(type) + latestVersionText + "\n\n" + localVersionText + "\n\n";

--- a/plugin-core/src/main/java/appland/actions/PluginStatus.java
+++ b/plugin-core/src/main/java/appland/actions/PluginStatus.java
@@ -1,9 +1,10 @@
 package appland.actions;
 
 import appland.AppMapBundle;
-import appland.cli.AppLandDownloadService;
 import appland.cli.CliTool;
 import appland.cli.CliTools;
+import appland.cli.LocalAssetRepository;
+import appland.cli.ManifestManager;
 import appland.deployment.AppMapDeploymentSettingsService;
 import appland.javaAgent.JavaAgentStatus;
 import appland.telemetry.SplunkTelemetryUtils;
@@ -20,7 +21,6 @@ import com.intellij.testFramework.LightVirtualFile;
 import com.intellij.util.concurrency.annotations.RequiresBackgroundThread;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
 import java.util.Objects;
 
 public class PluginStatus extends AnAction implements DumbAware {
@@ -106,19 +106,13 @@ public class PluginStatus extends AnAction implements DumbAware {
 
     @NotNull
     private static String appmapBinaryStatusReport(@NotNull CliTool type) {
-        var service = AppLandDownloadService.getInstance();
-
-        String latestVersion;
-        try {
-            latestVersion = service.fetchLatestRemoteVersion(type);
-        } catch (IOException e) {
-            latestVersion = null;
-        }
+        var manifest = ManifestManager.fetch(type);
+        var latestVersion = manifest != null ? manifest.version : null;
 
         String latestVersionText = String.format("Latest version: %s",
                 latestVersion == null ? "Failed to check for the latest version" : latestVersion);
 
-        var downloadedVersion = service.findLatestDownloadedVersion(type);
+        var downloadedVersion = LocalAssetRepository.getInstalledVersion(type);
         var downloadPath = CliTools.getBinaryPath(type);
 
         String localVersionText = "Your version: ";

--- a/plugin-core/src/main/java/appland/cli/AppLandDownloadService.java
+++ b/plugin-core/src/main/java/appland/cli/AppLandDownloadService.java
@@ -1,14 +1,8 @@
 package appland.cli;
 
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
-import com.intellij.util.concurrency.annotations.RequiresBackgroundThread;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.io.IOException;
-import java.nio.file.Path;
 
 /**
  * Application service managing the downloads of CLI binaries.
@@ -19,47 +13,7 @@ public interface AppLandDownloadService {
     }
 
     /**
-     * @param type     The type of CLI tool
-     * @param platform The platform to search for
-     * @param arch     The architecture to search for
-     * @return The location on disk, where the binary for the given tool type is stored.
-     * It's possible that the file does not exist yet.
-     */
-    @Nullable Path getDownloadFilePath(@NotNull CliTool type, @NotNull String platform, @NotNull String arch);
-
-    /**
-     * Download a new copy of the tool binary and store it at the expected location on disk.
-     * It notifies via {@link AppLandDownloadListener} when the download completed.
-     *
-     * @param type              Type of commandline tool
-     * @param version           Version to download
-     * @param progressIndicator Indicator to show the download progress
-     * @return A {@link AppMapDownloadStatus} value indicating the result of the download.
-     */
-    @RequiresBackgroundThread
-    @NotNull AppMapDownloadStatus download(@NotNull CliTool type,
-                                           @NotNull String version,
-                                           @NotNull ProgressIndicator progressIndicator);
-
-    /**
-     * Fetch metadata about the latest available version
-     *
-     * @param type Type of command line tool
-     * @return Available version of {@code null} if the retrieval was unsuccessful
-     */
-    @RequiresBackgroundThread
-    @Nullable String fetchLatestRemoteVersion(@NotNull CliTool type) throws IOException;
-
-    /**
      * Starts tasks to download the latest available versions of the needed CLI binaries.
      */
-    void queueDownloadTasks(@NotNull Project project) throws IOException;
-
-    /**
-     * Fetch the latest version that has been downloaded.
-     *
-     * @param type Type of command line tool
-     * @return Latest available version or {@code null} if the retrieval was unsuccessful
-     */
-    @Nullable String findLatestDownloadedVersion(@NotNull CliTool type);
+    void queueDownloadTasks(@NotNull Project project);
 }

--- a/plugin-core/src/main/java/appland/cli/CliPlatform.java
+++ b/plugin-core/src/main/java/appland/cli/CliPlatform.java
@@ -1,0 +1,38 @@
+package appland.cli;
+
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.util.system.CpuArch;
+import org.jetbrains.annotations.NotNull;
+
+public final class CliPlatform {
+
+    private CliPlatform() {
+    }
+
+    /**
+     * @return The platform identifier string formatted for manifest mapping (e.g., "linux-x64", "macos-arm64", "win-x64").
+     */
+    public static @NotNull String getId() {
+        return currentPlatform() + "-" + currentArch();
+    }
+
+    public static @NotNull String currentPlatform() {
+        if (SystemInfo.isLinux) {
+            return "linux";
+        }
+
+        if (SystemInfo.isMac) {
+            return "macos";
+        }
+
+        if (SystemInfo.isWindows) {
+            return "win";
+        }
+
+        throw new IllegalStateException("Unsupported platform: " + SystemInfo.getOsNameAndVersion());
+    }
+
+    public static @NotNull String currentArch() {
+        return CpuArch.isArm64() ? "arm64" : "x64";
+    }
+}

--- a/plugin-core/src/main/java/appland/cli/CliTool.java
+++ b/plugin-core/src/main/java/appland/cli/CliTool.java
@@ -10,35 +10,25 @@ import org.jetbrains.annotations.NotNull;
  */
 @Getter
 public enum CliTool {
-    AppMap("appmap",
-            "https://github.com/getappmap/appmap-js/releases/download/@appland/appmap",
-            AppMapBundle.get("cli.appMap.name")),
-    Scanner("scanner",
-            "https://github.com/getappmap/appmap-js/releases/download/@appland/scanner",
-            AppMapBundle.get("cli.scanner.name"));
+    AppMap("appmap", AppMapBundle.get("cli.appMap.name")),
+    Scanner("scanner", AppMapBundle.get("cli.scanner.name"));
 
     private final String id;
-    private final String baseURL;
     private final String presentableName;
 
-    CliTool(@NotNull String id, @NotNull String baseURL, String presentableName) {
+    CliTool(@NotNull String id, String presentableName) {
         this.id = id;
-        this.baseURL = baseURL;
         this.presentableName = presentableName;
     }
 
     /**
-     * @param platform "macos", "linux", or "win"
+     * @param platform "linux", "macos", or "win"
      * @param arch     "x64" or "arm64"
      * @return The name of the binary for the given platform and architecture.
-     * The name is used locally and to build the download URL.
+     * The name is used locally.
      */
     public @NotNull String getBinaryName(@NotNull String platform, @NotNull String arch) {
         var suffix = "win".equals(platform) ? ".exe" : "";
         return id + "-" + platform + "-" + arch + suffix;
-    }
-
-    public @NotNull String getDownloadUrl(@NotNull String version, @NotNull String platform, @NotNull String arch) {
-        return baseURL + "-v" + version + "/" + getBinaryName(platform, arch);
     }
 }

--- a/plugin-core/src/main/java/appland/cli/CliTool.java
+++ b/plugin-core/src/main/java/appland/cli/CliTool.java
@@ -31,4 +31,13 @@ public enum CliTool {
         var suffix = "win".equals(platform) ? ".exe" : "";
         return id + "-" + platform + "-" + arch + suffix;
     }
+
+    /**
+     * @return The versioned filename for the cached binary, e.g. "appmap-linux-x64-1.2.3".
+     * Matches the naming convention used by the VSCode AppMap extension.
+     */
+    public @NotNull String getBinaryName(@NotNull String platform, @NotNull String arch, @NotNull String version) {
+        var suffix = "win".equals(platform) ? ".exe" : "";
+        return id + "-" + platform + "-" + arch + "-" + version + suffix;
+    }
 }

--- a/plugin-core/src/main/java/appland/cli/CliTools.java
+++ b/plugin-core/src/main/java/appland/cli/CliTools.java
@@ -1,7 +1,6 @@
 package appland.cli;
 
 import appland.deployment.AppMapDeploymentSettingsService;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.text.SemVer;
 import org.jetbrains.annotations.NotNull;
@@ -31,10 +30,9 @@ public final class CliTools {
     }
 
     /**
-     * @return The path to the binary, if it exists.
-     * All matching bundled binaries and a downloaded binary (if it exists) are searched.
-     * The binary with the highest version number is returned.
-     * If both a bundled binary and the downloaded binary have the highest version, the bundled binary is returned.
+     * @return The path to the binary for the current platform, if it exists.
+     * The installed binary (symlink or Windows copy in ~/.appmap/bin) is preferred.
+     * Falls back to the best matching bundled binary.
      */
     public static @Nullable Path getBinaryPath(@NotNull CliTool type) {
         return getBinaryPath(type, CliPlatform.currentPlatform(), CliPlatform.currentArch());
@@ -42,56 +40,36 @@ public final class CliTools {
 
     /**
      * @return The path to the binary, if it exists.
-     * All matching bundled binaries and a downloaded binary (if it exists) are searched.
-     * The binary with the highest version number is returned.
-     * If both a bundled binary and the downloaded binary have the highest version, the bundled binary is returned.
+     * The installed binary (symlink or Windows copy in ~/.appmap/bin) is preferred.
+     * Falls back to the best matching bundled binary for the given platform and arch.
      */
     public static @Nullable Path getBinaryPath(@NotNull CliTool type, @NotNull String platform, @NotNull String arch) {
-        var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
-        var activeVersion = LocalAssetRepository.getActiveVersion(type, unitTestMode);
-        
-        if (activeVersion != null) {
-            var activePath = LocalAssetRepository.getExecutableFilePath(type, activeVersion, platform, arch, unitTestMode);
-            if (Files.exists(activePath)) {
-                try {
-                    fixBinaryPermissions(activePath);
-                    return activePath;
-                } catch (IOException e) {
-                    LOG.warn("Failed to make the active binary executable. Path: " + activePath, e);
-                }
+        var installedBinary = LocalAssetRepository.getInstalledBinaryPath(type);
+        if (installedBinary != null) {
+            try {
+                fixBinaryPermissions(installedBinary);
+                return installedBinary;
+            } catch (IOException e) {
+                LOG.warn("Failed to make the installed binary executable. Path: " + installedBinary, e);
             }
         }
 
-        var downloadedBinary = LocalAssetRepository.getInstalledBinaryPath(type, platform, arch);
+        // Fall back to the best bundled binary when nothing has been downloaded yet.
         var bestBundledBinary = AppMapDeploymentSettingsService.getInstance()
                 .findBundledBinaries(type, platform, arch)
                 .filter(Files::exists)
                 .max(pathComparator)
                 .orElse(null);
 
-        Path selectedBinary = null;
         if (bestBundledBinary == null) {
-            selectedBinary = downloadedBinary;
-        } else if (downloadedBinary == null) {
-            selectedBinary = bestBundledBinary;
-        } else {
-            // == 0: same version, prefer the bundled binary
-            // < 0: the downloaded binary has a lower version, prefer the bundled binary
-            int compareValue = pathComparator.compare(downloadedBinary, bestBundledBinary);
-            selectedBinary = compareValue == 0 || compareValue < 0
-                    ? bestBundledBinary
-                    : downloadedBinary;
-        }
-
-        if (selectedBinary == null) {
             return null;
         }
 
         try {
-            fixBinaryPermissions(selectedBinary);
-            return selectedBinary;
+            fixBinaryPermissions(bestBundledBinary);
+            return bestBundledBinary;
         } catch (IOException e) {
-            LOG.warn("Failed to make the binary executable. Path: " + selectedBinary, e);
+            LOG.warn("Failed to make the bundled binary executable. Path: " + bestBundledBinary, e);
             return null;
         }
     }

--- a/plugin-core/src/main/java/appland/cli/CliTools.java
+++ b/plugin-core/src/main/java/appland/cli/CliTools.java
@@ -1,6 +1,7 @@
 package appland.cli;
 
 import appland.deployment.AppMapDeploymentSettingsService;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.text.SemVer;
 import org.jetbrains.annotations.NotNull;
@@ -46,25 +47,45 @@ public final class CliTools {
      * If both a bundled binary and the downloaded binary have the highest version, the bundled binary is returned.
      */
     public static @Nullable Path getBinaryPath(@NotNull CliTool type, @NotNull String platform, @NotNull String arch) {
-        var downloadedBinary = AppLandDownloadService.getInstance().getDownloadFilePath(type, platform, arch);
+        var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
+        var activeVersion = LocalAssetRepository.getActiveVersion(type, unitTestMode);
+        
+        if (activeVersion != null) {
+            var activePath = LocalAssetRepository.getExecutableFilePath(type, activeVersion, platform, arch, unitTestMode);
+            if (Files.exists(activePath)) {
+                try {
+                    fixBinaryPermissions(activePath);
+                    return activePath;
+                } catch (IOException e) {
+                    LOG.warn("Failed to make the active binary executable. Path: " + activePath, e);
+                }
+            }
+        }
+
+        var downloadedBinary = LocalAssetRepository.getInstalledBinaryPath(type, platform, arch);
         var bestBundledBinary = AppMapDeploymentSettingsService.getInstance()
                 .findBundledBinaries(type, platform, arch)
                 .filter(Files::exists)
                 .max(pathComparator)
                 .orElse(null);
 
+        Path selectedBinary = null;
         if (bestBundledBinary == null) {
-            return downloadedBinary;
+            selectedBinary = downloadedBinary;
         } else if (downloadedBinary == null) {
-            return bestBundledBinary;
+            selectedBinary = bestBundledBinary;
+        } else {
+            // == 0: same version, prefer the bundled binary
+            // < 0: the downloaded binary has a lower version, prefer the bundled binary
+            int compareValue = pathComparator.compare(downloadedBinary, bestBundledBinary);
+            selectedBinary = compareValue == 0 || compareValue < 0
+                    ? bestBundledBinary
+                    : downloadedBinary;
         }
 
-        // == 0: same version, prefer the bundled binary
-        // < 0: the downloaded binary has a lower version, prefer the bundled binary
-        int compareValue = pathComparator.compare(downloadedBinary, bestBundledBinary);
-        var selectedBinary = compareValue == 0 || compareValue < 0
-                ? bestBundledBinary
-                : downloadedBinary;
+        if (selectedBinary == null) {
+            return null;
+        }
 
         try {
             fixBinaryPermissions(selectedBinary);

--- a/plugin-core/src/main/java/appland/cli/CliTools.java
+++ b/plugin-core/src/main/java/appland/cli/CliTools.java
@@ -2,8 +2,6 @@ package appland.cli;
 
 import appland.deployment.AppMapDeploymentSettingsService;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.util.SystemInfo;
-import com.intellij.util.system.CpuArch;
 import com.intellij.util.text.SemVer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,7 +36,7 @@ public final class CliTools {
      * If both a bundled binary and the downloaded binary have the highest version, the bundled binary is returned.
      */
     public static @Nullable Path getBinaryPath(@NotNull CliTool type) {
-        return getBinaryPath(type, currentPlatform(), currentArch());
+        return getBinaryPath(type, CliPlatform.currentPlatform(), CliPlatform.currentArch());
     }
 
     /**
@@ -82,32 +80,6 @@ public final class CliTools {
             SemVerComparator.INSTANCE);
 
     /**
-     * package-visible for our tests
-     */
-    public static @NotNull String currentPlatform() {
-        if (SystemInfo.isLinux) {
-            return "linux";
-        }
-
-        if (SystemInfo.isMac) {
-            return "macos";
-        }
-
-        if (SystemInfo.isWindows) {
-            return "win";
-        }
-
-        throw new IllegalStateException("Unsupported platform: " + SystemInfo.getOsNameAndVersion());
-    }
-
-    /**
-     * package-visible for our tests
-     */
-    public static @NotNull String currentArch() {
-        return CpuArch.isArm64() ? "arm64" : "x64";
-    }
-
-    /**
      * @return The first SemVer match in the given string, or {@code null} if there is no match.
      */
     public static @Nullable SemVer extractVersion(@NotNull String value) {
@@ -123,8 +95,9 @@ public final class CliTools {
      * On Windows, do nothing.
      */
     public static void fixBinaryPermissions(Path downloadTargetFilePath) throws IOException {
-        if (SystemInfo.isUnix && !Files.isExecutable(downloadTargetFilePath)) {
+        if (com.intellij.openapi.util.SystemInfo.isUnix && !Files.isExecutable(downloadTargetFilePath)) {
             Files.setPosixFilePermissions(downloadTargetFilePath, Set.of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE, GROUP_READ, OTHERS_READ));
         }
     }
 }
+

--- a/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
@@ -8,7 +8,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.io.NioFiles;
 import com.intellij.util.io.HttpRequests;
 import org.jetbrains.annotations.NotNull;
 
@@ -20,7 +19,9 @@ import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 
 /**
- * Downloads are stored as "appland-downloads/$NAME/$VERSION/$NAME-$OS-$ARCH", e.g. "appland-downloads/appmap/1.2.3/appmap-linux-x64".
+ * Downloads are cached as "$NAME-$OS-$ARCH-$VERSION" in the platform-specific cache directory,
+ * e.g. "appmap-linux-x64-1.2.3" in ~/.cache/appmap/ on Linux.
+ * This matches the layout used by the VSCode AppMap extension so both share the same cache.
  */
 public class DefaultAppLandDownloadService implements AppLandDownloadService {
     private static final Logger LOG = Logger.getInstance(DefaultAppLandDownloadService.class);
@@ -78,10 +79,10 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
             return AppMapDownloadStatus.Failed;
         }
 
-        try {
-            var targetFilePath = LocalAssetRepository.getExecutableFilePath(type, version, platform, arch, unitTestMode);
-            var downloadTargetFilePath = targetFilePath.resolveSibling(targetFilePath.getFileName().toString() + ".download");
+        var targetFilePath = LocalAssetRepository.getExecutableFilePath(type, version, platform, arch, unitTestMode);
+        var downloadTargetFilePath = targetFilePath.resolveSibling(targetFilePath.getFileName().toString() + ".download");
 
+        try {
             Files.createDirectories(targetFilePath.getParent());
             Files.deleteIfExists(targetFilePath);
             Files.deleteIfExists(downloadTargetFilePath);
@@ -110,13 +111,11 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
         } catch (Exception e) {
             LOG.debug("Error downloading CLI binary", e);
 
-            var downloadDir = LocalAssetRepository.getVersionDownloadDirectory(type, version, unitTestMode);
             try {
-                if (Files.isDirectory(downloadDir)) {
-                    NioFiles.deleteRecursively(downloadDir);
-                }
+                Files.deleteIfExists(targetFilePath);
+                Files.deleteIfExists(downloadTargetFilePath);
             } catch (IOException ex) {
-                LOG.debug("Error cleaning up download directory: " + downloadDir, e);
+                LOG.debug("Error cleaning up failed download: " + targetFilePath, ex);
             }
 
             notifyDownloadFinished(type, AppMapDownloadStatus.Failed);

--- a/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
@@ -6,14 +6,11 @@ import appland.settings.DownloadSettings;
 import appland.utils.GsonUtils;
 import com.google.gson.JsonArray;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.SystemInfo;
-import com.intellij.openapi.util.Version;
 import com.intellij.openapi.util.io.NioFiles;
 import com.intellij.util.Urls;
 import com.intellij.util.io.HttpRequests;
@@ -23,13 +20,9 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static appland.cli.CliTools.currentArch;
-import static appland.cli.CliTools.currentPlatform;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Downloads are stored as "appland-downloads/$NAME/$VERSION/$NAME-$OS-$ARCH", e.g. "appland-downloads/appmap/1.2.3/appmap-linux-x64".
@@ -42,13 +35,13 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
 
     @Override
     public @Nullable Path getDownloadFilePath(@NotNull CliTool type, @NotNull String platform, @NotNull String arch) {
-        var version = findLatestDownloadedVersion(type);
+        var version = LocalAssetRepository.findLatestDownloadedVersion(type);
         if (version == null) {
             return null;
         }
 
         var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
-        return getExecutableFilePath(type, version, platform, arch, unitTestMode);
+        return LocalAssetRepository.getExecutableFilePath(type, version, platform, arch, unitTestMode);
     }
 
     @Override
@@ -63,11 +56,11 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
         var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
 
         try {
-            var platform = currentPlatform();
-            var arch = currentArch();
+            var platform = CliPlatform.currentPlatform();
+            var arch = CliPlatform.currentArch();
 
             // the path to the downloaded executable
-            var targetFilePath = getExecutableFilePath(type, version, platform, arch, unitTestMode);
+            var targetFilePath = LocalAssetRepository.getExecutableFilePath(type, version, platform, arch, unitTestMode);
             // the path where the in-progress download is stored
             var downloadTargetFilePath = targetFilePath.resolveSibling(targetFilePath.getFileName().toString() + ".download");
 
@@ -89,7 +82,7 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
             Files.move(downloadTargetFilePath, targetFilePath, StandardCopyOption.ATOMIC_MOVE);
 
             // after a successful download, remove previous downloads, make sure to keep the new download
-            removeOtherVersions(type, version, unitTestMode);
+            LocalAssetRepository.removeOtherVersions(type, version, unitTestMode);
 
             notifyDownloadFinished(type, AppMapDownloadStatus.Successful);
             return AppMapDownloadStatus.Successful;
@@ -97,7 +90,7 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
             LOG.debug("Error downloading CLI binary", e);
 
             // cleanup failed download, if available
-            var downloadDir = getVersionDownloadDirectory(type, version, unitTestMode);
+            var downloadDir = LocalAssetRepository.getVersionDownloadDirectory(type, version, unitTestMode);
             try {
                 if (Files.isDirectory(downloadDir)) {
                     NioFiles.deleteRecursively(downloadDir);
@@ -135,90 +128,15 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
         }
     }
 
+    @Override
     public @Nullable String findLatestDownloadedVersion(@NotNull CliTool type) {
-        var directory = getToolDownloadDirectory(type, ApplicationManager.getApplication().isUnitTestMode());
-        if (!Files.isDirectory(directory)) {
-            return null;
-        }
-
-        var candidates = findVersionDownloadDirectories(directory);
-        if (candidates.isEmpty()) {
-            return null;
-        }
-
-        return candidates
-                .stream()
-                .map(file -> file.getFileName().toString())
-                .max(Comparator.naturalOrder())
-                .orElse(null);
-    }
-
-    private boolean isDownloaded(@NotNull CliTool type, @NotNull String version, boolean unitTestMode) {
-        return isExecutableBinary(getExecutableFilePath(type, version, currentPlatform(), currentArch(), unitTestMode));
-    }
-
-    private boolean isExecutableBinary(@NotNull Path file) {
-        return Files.isRegularFile(file) && (!SystemInfo.isUnix || Files.isExecutable(file));
-    }
-
-    static @NotNull List<Path> findVersionDownloadDirectories(@NotNull Path parentDirectory) {
-        try (var stream = Files.list(parentDirectory)) {
-            return stream
-                    .filter(file -> Files.isDirectory(file) && Version.parseVersion(file.getFileName().toString()) != null)
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            LOG.debug("Error listing download directory entries: " + parentDirectory, e);
-            return Collections.emptyList();
-        }
-    }
-
-    static void removeOtherVersions(@NotNull CliTool type, @NotNull String keepVersion, boolean unitTestMode) {
-        removeOtherVersions(getToolDownloadDirectory(type, unitTestMode), keepVersion);
-    }
-
-    @NotNull
-    static List<Path> removeOtherVersions(@NotNull Path directory, @NotNull String keepVersion) {
-        var toRemove = findVersionDownloadDirectories(directory)
-                .stream()
-                .filter(path -> !keepVersion.equals(path.getFileName().toString()))
-                .collect(Collectors.toList());
-
-        if (!toRemove.isEmpty()) {
-            for (var path : toRemove) {
-                try {
-                    NioFiles.deleteRecursively(path);
-                } catch (IOException e) {
-                    LOG.debug("Error deleting download directory: " + path, e);
-                }
-            }
-        }
-        return toRemove;
-    }
-
-    static @NotNull Path getExecutableFilePath(@NotNull CliTool type,
-                                               @NotNull String version,
-                                               @NotNull String platform,
-                                               @NotNull String arch,
-                                               boolean unitTestMode) {
-        return getVersionDownloadDirectory(type, version, unitTestMode).resolve(type.getBinaryName(platform, arch));
-    }
-
-    static @NotNull Path getVersionDownloadDirectory(@NotNull CliTool type, @NotNull String version, boolean unitTestMode) {
-        return getToolDownloadDirectory(type, unitTestMode).resolve(version);
-    }
-
-    @NotNull
-    static Path getToolDownloadDirectory(@NotNull CliTool type, boolean unitTestMode) {
-        var basePath = unitTestMode || "true".equals(System.getProperty("appmap.sandbox"))
-                ? Paths.get(PathManager.getTempPath()).resolve("appland-downloads")
-                : Paths.get(PathManager.getDefaultSystemPathFor("appland-plugin"));
-        return basePath.resolve(type.getId());
+        return LocalAssetRepository.findLatestDownloadedVersion(type);
     }
 
     private void downloadTool(@NotNull Project project, @NotNull CliTool type) {
         LOG.debug("Downloading AppMap CLI tool: " + type);
         var latestVersion = fetchLatestRemoteVersion(type);
-        if (latestVersion != null && !isDownloaded(type, latestVersion, ApplicationManager.getApplication().isUnitTestMode())) {
+        if (latestVersion != null && !LocalAssetRepository.isDownloaded(type, latestVersion, CliPlatform.currentPlatform(), CliPlatform.currentArch(), ApplicationManager.getApplication().isUnitTestMode())) {
             var title = AppMapBundle.get("cliDownload.progress.title", type.getPresentableName());
             new Task.Backgroundable(project, title, true) {
                 @Override

--- a/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
@@ -104,7 +104,6 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
             CliTools.fixBinaryPermissions(downloadTargetFilePath);
             Files.move(downloadTargetFilePath, targetFilePath, StandardCopyOption.ATOMIC_MOVE);
             LocalAssetRepository.setActiveVersion(type, version, unitTestMode);
-            LocalAssetRepository.removeOtherVersions(type, version, unitTestMode);
 
             notifyDownloadFinished(type, AppMapDownloadStatus.Successful);
             return AppMapDownloadStatus.Successful;

--- a/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
@@ -40,12 +40,27 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
             return AppMapDownloadStatus.Skipped;
         }
 
+        var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
         var manifest = ManifestManager.fetch(type);
         var platform = CliPlatform.currentPlatform();
         var arch = CliPlatform.currentArch();
 
         if (manifest == null) {
             LOG.warn("Cannot fetch manifest for " + type.getId());
+            // Symlink already works — nothing to do.
+            if (LocalAssetRepository.getInstalledBinaryPath(type) != null) {
+                notifyDownloadFinished(type, AppMapDownloadStatus.Skipped);
+                return AppMapDownloadStatus.Skipped;
+            }
+
+            // Symlink is missing or broken — restore from the highest cached binary.
+            var cachedPath = LocalAssetRepository.findHighestCachedBinary(type, platform, arch, unitTestMode);
+            if (cachedPath != null) {
+                LOG.info("Restoring " + type.getId() + " symlink to cached " + LocalAssetRepository.versionFromPath(cachedPath));
+                LocalAssetRepository.updateSymlink(cachedPath, LocalAssetRepository.getSymlinkPath(type));
+                notifyDownloadFinished(type, AppMapDownloadStatus.Successful);
+                return AppMapDownloadStatus.Successful;
+            }
 
             // A bundled binary (from deployment settings) is still usable even without a download.
             if (CliTools.getBinaryPath(type, platform, arch) != null) {
@@ -58,12 +73,13 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
         }
 
         var version = manifest.version;
-        var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
 
         if (LocalAssetRepository.isDownloaded(type, version, platform, arch, unitTestMode)) {
-            var currentActive = LocalAssetRepository.getActiveVersion(type, unitTestMode);
-            if (!version.equals(currentActive)) {
-                LocalAssetRepository.setActiveVersion(type, version, unitTestMode);
+            var cachedPath = LocalAssetRepository.getExecutableFilePath(type, version, platform, arch, unitTestMode);
+            var symlinkPath = LocalAssetRepository.getSymlinkPath(type);
+            if (!LocalAssetRepository.symlinkPointsTo(symlinkPath, cachedPath)) {
+                LOG.info("Updating " + type.getId() + " symlink to version " + version);
+                LocalAssetRepository.updateSymlink(cachedPath, symlinkPath);
                 notifyDownloadFinished(type, AppMapDownloadStatus.Successful);
                 return AppMapDownloadStatus.Successful;
             }
@@ -104,7 +120,7 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
 
             CliTools.fixBinaryPermissions(downloadTargetFilePath);
             Files.move(downloadTargetFilePath, targetFilePath, StandardCopyOption.ATOMIC_MOVE);
-            LocalAssetRepository.setActiveVersion(type, version, unitTestMode);
+            LocalAssetRepository.updateSymlink(targetFilePath, LocalAssetRepository.getSymlinkPath(type));
 
             notifyDownloadFinished(type, AppMapDownloadStatus.Successful);
             return AppMapDownloadStatus.Successful;

--- a/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultAppLandDownloadService.java
@@ -3,93 +3,114 @@ package appland.cli;
 import appland.AppMapBundle;
 import appland.github.GitHubHttpRequests;
 import appland.settings.DownloadSettings;
-import appland.utils.GsonUtils;
-import com.google.gson.JsonArray;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.NioFiles;
-import com.intellij.util.Urls;
 import com.intellij.util.io.HttpRequests;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.HashMap;
-import java.util.Map;
+import java.security.MessageDigest;
 
 /**
  * Downloads are stored as "appland-downloads/$NAME/$VERSION/$NAME-$OS-$ARCH", e.g. "appland-downloads/appmap/1.2.3/appmap-linux-x64".
  */
 public class DefaultAppLandDownloadService implements AppLandDownloadService {
     private static final Logger LOG = Logger.getInstance(DefaultAppLandDownloadService.class);
-    private static final String LATEST_CLI_VERSIONS_URL = "https://api.github.com/repos/getappmap/appmap-js/releases";
-    private final Object lock = new Object();
-    private volatile Map<CliTool, String> cachedReleaseVersions = null;
 
     @Override
-    public @Nullable Path getDownloadFilePath(@NotNull CliTool type, @NotNull String platform, @NotNull String arch) {
-        var version = LocalAssetRepository.findLatestDownloadedVersion(type);
-        if (version == null) {
-            return null;
+    public void queueDownloadTasks(@NotNull Project project) {
+        if (DownloadSettings.isAssetDownloadEnabled()) {
+            downloadTool(project, CliTool.AppMap);
+            downloadTool(project, CliTool.Scanner);
         }
-
-        var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
-        return LocalAssetRepository.getExecutableFilePath(type, version, platform, arch, unitTestMode);
     }
 
-    @Override
-    public @NotNull AppMapDownloadStatus download(@NotNull CliTool type,
-                                                  @NotNull String version,
-                                                  @NotNull ProgressIndicator progressIndicator) {
+    @NotNull AppMapDownloadStatus download(@NotNull CliTool type, @NotNull ProgressIndicator progressIndicator) {
         if (DownloadSettings.isAssetDownloadDisabled()) {
             notifyDownloadFinished(type, AppMapDownloadStatus.Skipped);
             return AppMapDownloadStatus.Skipped;
         }
 
+        var manifest = ManifestManager.fetch(type);
+        var platform = CliPlatform.currentPlatform();
+        var arch = CliPlatform.currentArch();
+
+        if (manifest == null) {
+            LOG.warn("Cannot fetch manifest for " + type.getId());
+
+            // A bundled binary (from deployment settings) is still usable even without a download.
+            if (CliTools.getBinaryPath(type, platform, arch) != null) {
+                notifyDownloadFinished(type, AppMapDownloadStatus.Skipped);
+                return AppMapDownloadStatus.Skipped;
+            }
+
+            notifyDownloadFinished(type, AppMapDownloadStatus.Failed);
+            return AppMapDownloadStatus.Failed;
+        }
+
+        var version = manifest.version;
         var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
 
-        try {
-            var platform = CliPlatform.currentPlatform();
-            var arch = CliPlatform.currentArch();
+        if (LocalAssetRepository.isDownloaded(type, version, platform, arch, unitTestMode)) {
+            var currentActive = LocalAssetRepository.getActiveVersion(type, unitTestMode);
+            if (!version.equals(currentActive)) {
+                LocalAssetRepository.setActiveVersion(type, version, unitTestMode);
+                notifyDownloadFinished(type, AppMapDownloadStatus.Successful);
+                return AppMapDownloadStatus.Successful;
+            }
+            notifyDownloadFinished(type, AppMapDownloadStatus.Skipped);
+            return AppMapDownloadStatus.Skipped;
+        }
 
-            // the path to the downloaded executable
+        var platformId = CliPlatform.getId();
+        var source = manifest.getAsset(platformId);
+        if (source == null) {
+            LOG.warn("No " + type.getId() + " asset for " + platformId + " in manifest");
+            notifyDownloadFinished(type, AppMapDownloadStatus.Failed);
+            return AppMapDownloadStatus.Failed;
+        }
+
+        try {
             var targetFilePath = LocalAssetRepository.getExecutableFilePath(type, version, platform, arch, unitTestMode);
-            // the path where the in-progress download is stored
             var downloadTargetFilePath = targetFilePath.resolveSibling(targetFilePath.getFileName().toString() + ".download");
 
-            // final and temp file paths have the same parent
             Files.createDirectories(targetFilePath.getParent());
             Files.deleteIfExists(targetFilePath);
             Files.deleteIfExists(downloadTargetFilePath);
 
-            // download the file, it throws an IOException if it fails or if the remote file is unavailable
-            var url = type.getDownloadUrl(version, platform, arch);
-            LOG.debug(String.format("Downloading CLI binary %s from %s to %s", type.getId(), url, targetFilePath));
-            HttpRequests.request(url)
+            LOG.info(String.format("Downloading CLI binary %s from %s to %s", type.getId(), source.url, targetFilePath));
+            HttpRequests.request(source.url)
                     .tuner(GitHubHttpRequests.gitHubTokenTuner())
                     .saveToFile(downloadTargetFilePath, progressIndicator);
 
+            if (source.digest != null) {
+                if (!verifyDigest(downloadTargetFilePath, source.digest)) {
+                    LOG.warn("Digest verification failed for " + type.getId() + " version " + version);
+                    Files.deleteIfExists(downloadTargetFilePath);
+                    notifyDownloadFinished(type, AppMapDownloadStatus.Failed);
+                    return AppMapDownloadStatus.Failed;
+                }
+                LOG.info("Verified digest for " + type.getId() + " version " + version);
+            }
+
             CliTools.fixBinaryPermissions(downloadTargetFilePath);
-
-            // now move the downloaded file to the expected path
             Files.move(downloadTargetFilePath, targetFilePath, StandardCopyOption.ATOMIC_MOVE);
-
-            // after a successful download, remove previous downloads, make sure to keep the new download
+            LocalAssetRepository.setActiveVersion(type, version, unitTestMode);
             LocalAssetRepository.removeOtherVersions(type, version, unitTestMode);
 
             notifyDownloadFinished(type, AppMapDownloadStatus.Successful);
             return AppMapDownloadStatus.Successful;
-        } catch (IOException e) {
+        } catch (Exception e) {
             LOG.debug("Error downloading CLI binary", e);
 
-            // cleanup failed download, if available
             var downloadDir = LocalAssetRepository.getVersionDownloadDirectory(type, version, unitTestMode);
             try {
                 if (Files.isDirectory(downloadDir)) {
@@ -104,51 +125,47 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
         }
     }
 
-    @Override
-    public @Nullable String fetchLatestRemoteVersion(@NotNull CliTool type) {
-        if (this.cachedReleaseVersions == null) {
-            synchronized (this.lock) {
-                if (this.cachedReleaseVersions == null) {
-                    this.cachedReleaseVersions = fetchLatestReleases(ProgressManager.getGlobalProgressIndicator());
-                }
+    private boolean verifyDigest(Path path, String expectedDigest) throws Exception {
+        var parts = expectedDigest.split(":", 2);
+        if (parts.length != 2 || !parts[0].equals("sha256")) {
+            LOG.warn("Unsupported digest algorithm: " + (parts.length > 0 ? parts[0] : "none"));
+            return false;
+        }
+        var expectedHash = parts[1];
+
+        var digest = MessageDigest.getInstance("SHA-256");
+        try (InputStream is = Files.newInputStream(path)) {
+            var buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = is.read(buffer)) != -1) {
+                digest.update(buffer, 0, bytesRead);
             }
         }
-
-        // a null map indicates that the versions could not be fetched,
-        // a null version value indicates that the fetch was successful but no version was found
-        var releases = this.cachedReleaseVersions;
-        return releases != null ? releases.get(type) : null;
-    }
-
-    @Override
-    public void queueDownloadTasks(@NotNull Project project) {
-        if (DownloadSettings.isAssetDownloadEnabled()) {
-            downloadTool(project, CliTool.AppMap);
-            downloadTool(project, CliTool.Scanner);
+        var hashBytes = digest.digest();
+        var hexString = new StringBuilder(2 * hashBytes.length);
+        for (byte b : hashBytes) {
+            var hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
         }
-    }
 
-    @Override
-    public @Nullable String findLatestDownloadedVersion(@NotNull CliTool type) {
-        return LocalAssetRepository.findLatestDownloadedVersion(type);
+        return expectedHash.equalsIgnoreCase(hexString.toString());
     }
 
     private void downloadTool(@NotNull Project project, @NotNull CliTool type) {
-        LOG.debug("Downloading AppMap CLI tool: " + type);
-        var latestVersion = fetchLatestRemoteVersion(type);
-        if (latestVersion != null && !LocalAssetRepository.isDownloaded(type, latestVersion, CliPlatform.currentPlatform(), CliPlatform.currentArch(), ApplicationManager.getApplication().isUnitTestMode())) {
-            var title = AppMapBundle.get("cliDownload.progress.title", type.getPresentableName());
-            new Task.Backgroundable(project, title, true) {
-                @Override
-                public void run(@NotNull ProgressIndicator indicator) {
-                    var status = download(type, latestVersion, indicator);
-                    switch (status) {
-                        case Failed -> LOG.debug("Download of CLI tool failed: " + type);
-                        case Skipped -> LOG.debug("Download of CLI tool was skipped: " + type);
-                    }
+        var title = AppMapBundle.get("cliDownload.progress.title", type.getPresentableName());
+        new Task.Backgroundable(project, title, true) {
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                var status = download(type, indicator);
+                switch (status) {
+                    case Failed -> LOG.warn("Download of CLI tool failed: " + type);
+                    case Skipped -> LOG.debug("Download of CLI tool was skipped: " + type);
                 }
-            }.queue();
-        }
+            }
+        }.queue();
     }
 
     private static void notifyDownloadFinished(@NotNull CliTool type, AppMapDownloadStatus status) {
@@ -162,50 +179,5 @@ public class DefaultAppLandDownloadService implements AppLandDownloadService {
                 }
             });
         }
-    }
-
-    static @Nullable Map<CliTool, String> fetchLatestReleases(@Nullable ProgressIndicator progressIndicator) {
-        try {
-            var jsonString = HttpRequests.request(Urls.newFromEncoded(LATEST_CLI_VERSIONS_URL))
-                    .tuner(GitHubHttpRequests.gitHubTokenTuner())
-                    .readString(progressIndicator);
-
-            var json = GsonUtils.GSON.fromJson(jsonString, JsonArray.class);
-            if (json != null && json.isJsonArray()) {
-                // non-null values because unmodifiable maps don't support them
-                var versions = new HashMap<CliTool, @NotNull String>();
-                for (var tool : CliTool.values()) {
-                    var version = parseLatestVersion(tool, json);
-                    if (version == null) {
-                        LOG.debug("No release version found for " + tool.getId());
-                    } else {
-                        versions.put(tool, version);
-                    }
-                }
-                return Map.copyOf(versions);
-            }
-        } catch (IOException e) {
-            LOG.debug("Error fetching latest CLI versions from " + LATEST_CLI_VERSIONS_URL, e);
-        }
-
-        return null;
-    }
-
-    static @Nullable String parseLatestVersion(@NotNull CliTool type, @NotNull JsonArray releases) {
-        var prefix = "@appland/" + type.getId() + "-v";
-        for (var release : releases) {
-            var releaseObj = release.getAsJsonObject();
-            if (releaseObj.has("tag_name")) {
-                var tagName = releaseObj.getAsJsonPrimitive("tag_name").getAsString();
-                if (tagName.startsWith(prefix)) {
-                    var version = tagName.substring(prefix.length());
-                    // verify it starts with a number, otherwise it's not the version
-                    if (!version.isEmpty() && Character.isDigit(version.charAt(0))) {
-                        return version;
-                    }
-                }
-            }
-        }
-        return null;
     }
 }

--- a/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
+++ b/plugin-core/src/main/java/appland/cli/DefaultCommandLineService.java
@@ -350,6 +350,8 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
             return null;
         }
 
+        LOG.info("Starting AppMap indexer using binary: " + indexerPath);
+
         var workingDir = AppMapVfsUtils.asNativePath(directory);
         var watchedDir = findWatchedAppMapDirectory(workingDir);
         prepareWatchedDirectory(watchedDir);
@@ -387,6 +389,8 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
         if (scannerPath == null || Files.notExists(scannerPath)) {
             return null;
         }
+
+        LOG.info("Starting AppMap scanner using binary: " + scannerPath);
 
         var workingDir = AppMapVfsUtils.asNativePath(directory);
         var watchedDir = findWatchedAppMapDirectory(workingDir);
@@ -515,6 +519,7 @@ public class DefaultCommandLineService implements AppLandCommandLineService {
             return;
         }
 
+        LOG.info("Stopping AppMap process: " + process.getCommandLine());
         NEXT_RESTART_DELAY.set(process, 0L);
         try {
             var shutdownRunnable = new Runnable() {

--- a/plugin-core/src/main/java/appland/cli/DownloadToolsStartupActivity.java
+++ b/plugin-core/src/main/java/appland/cli/DownloadToolsStartupActivity.java
@@ -9,7 +9,6 @@ import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -27,17 +26,13 @@ public class DownloadToolsStartupActivity extends ProjectActivityAdapter impleme
         }
 
         if (ACTIVE.compareAndSet(false, true)) {
-            try {
-                if (DownloadSettings.isAssetDownloadDisabled() && CliTools.getBinaryPath(CliTool.AppMap) == null) {
-                    // Show a notification but still continue with queueDownloadTasks avoid assumptions about its
-                    // implementation.
-                    AppMapNotifications.showAppMapBinaryUnavailableNotification(project);
-                }
-
-                AppLandDownloadService.getInstance().queueDownloadTasks(project);
-            } catch (IOException e) {
-                LOG.warn("Download of CLI binaries failed", e);
+            if (DownloadSettings.isAssetDownloadDisabled() && CliTools.getBinaryPath(CliTool.AppMap) == null) {
+                // Show a notification but still continue with queueDownloadTasks avoid assumptions about its
+                // implementation.
+                AppMapNotifications.showAppMapBinaryUnavailableNotification(project);
             }
+
+            AppLandDownloadService.getInstance().queueDownloadTasks(project);
         }
     }
 }

--- a/plugin-core/src/main/java/appland/cli/FailedDownloadNotificationListener.java
+++ b/plugin-core/src/main/java/appland/cli/FailedDownloadNotificationListener.java
@@ -13,7 +13,7 @@ public final class FailedDownloadNotificationListener implements AppLandDownload
 
     @Override
     public void downloadFinished(@NotNull CliTool type, @NotNull AppMapDownloadStatus status) {
-        if (!status.isSuccessful()) {
+        if (status == AppMapDownloadStatus.Failed) {
             AppMapNotifications.showFailedCliBinaryDownloadNotification(project);
         }
     }

--- a/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
+++ b/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
@@ -12,10 +12,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public final class LocalAssetRepository {
     private static final Logger LOG = Logger.getInstance(LocalAssetRepository.class);
@@ -24,6 +21,30 @@ public final class LocalAssetRepository {
     }
 
     private static final String ACTIVE_VERSION_FILE = "active-version.txt";
+
+    /**
+     * Returns the platform-specific cache directory for downloaded CLI binaries.
+     * Matches the location used by the VSCode AppMap extension so both plugins share cached downloads.
+     */
+    public static @NotNull Path getCacheDirectory(boolean unitTestMode) {
+        if (unitTestMode || "true".equals(System.getProperty("appmap.sandbox"))) {
+            return Paths.get(PathManager.getTempPath()).resolve("appland-downloads");
+        }
+        var home = Paths.get(System.getProperty("user.home"));
+        if (SystemInfo.isWindows) {
+            var localAppData = System.getenv("LOCALAPPDATA");
+            return localAppData != null
+                    ? Paths.get(localAppData, "AppMap", "cache")
+                    : home.resolve("AppData").resolve("Local").resolve("AppMap").resolve("cache");
+        } else if (SystemInfo.isMac) {
+            return home.resolve("Library").resolve("Caches").resolve("AppMap");
+        } else {
+            var xdgCacheHome = System.getenv("XDG_CACHE_HOME");
+            return xdgCacheHome != null
+                    ? Paths.get(xdgCacheHome).resolve("appmap")
+                    : home.resolve(".cache").resolve("appmap");
+        }
+    }
 
     public static @Nullable String getActiveVersion(@NotNull CliTool type, boolean unitTestMode) {
         var directory = getToolDownloadDirectory(type, unitTestMode);
@@ -56,30 +77,39 @@ public final class LocalAssetRepository {
      */
     public static @Nullable String getInstalledVersion(@NotNull CliTool type) {
         var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
-        var directory = getToolDownloadDirectory(type, unitTestMode);
-        if (!Files.isDirectory(directory)) {
-            return null;
-        }
-
-        var activeVersion = getActiveVersion(type, unitTestMode);
-        if (activeVersion != null && isDownloaded(type, activeVersion, CliPlatform.currentPlatform(), CliPlatform.currentArch(), unitTestMode)) {
-            return activeVersion;
-        }
-
-        var candidates = findVersionDownloadDirectories(directory);
-        if (candidates.isEmpty()) {
-            return null;
-        }
-
         var platform = CliPlatform.currentPlatform();
         var arch = CliPlatform.currentArch();
 
-        return candidates
-                .stream()
-                .map(file -> file.getFileName().toString())
-                .filter(v -> isDownloaded(type, v, platform, arch, unitTestMode))
-                .max(Comparator.naturalOrder())
-                .orElse(null);
+        var activeVersion = getActiveVersion(type, unitTestMode);
+        if (activeVersion != null && isDownloaded(type, activeVersion, platform, arch, unitTestMode)) {
+            return activeVersion;
+        }
+
+        return findHighestCachedVersion(type, platform, arch, unitTestMode);
+    }
+
+    private static @Nullable String findHighestCachedVersion(@NotNull CliTool type,
+                                                             @NotNull String platform,
+                                                             @NotNull String arch,
+                                                             boolean unitTestMode) {
+        var cacheDir = getCacheDirectory(unitTestMode);
+        var prefix = type.getId() + "-" + platform + "-" + arch + "-";
+        try (var stream = Files.list(cacheDir)) {
+            return stream
+                    .filter(p -> isExecutableBinary(p))
+                    .map(p -> p.getFileName().toString())
+                    .filter(name -> name.startsWith(prefix))
+                    .map(name -> {
+                        var stripped = name.endsWith(".exe") ? name.substring(0, name.length() - 4) : name;
+                        return stripped.substring(prefix.length());
+                    })
+                    .filter(v -> !v.isEmpty() && Version.parseVersion(v) != null)
+                    .max(Comparator.naturalOrder())
+                    .orElse(null);
+        } catch (IOException e) {
+            LOG.debug("Error scanning cache directory: " + cacheDir, e);
+            return null;
+        }
     }
 
     public static @Nullable Path getInstalledBinaryPath(@NotNull CliTool type, @NotNull String platform, @NotNull String arch) {
@@ -96,33 +126,23 @@ public final class LocalAssetRepository {
         return Files.isRegularFile(file) && (!SystemInfo.isUnix || Files.isExecutable(file));
     }
 
-    public static @NotNull List<Path> findVersionDownloadDirectories(@NotNull Path parentDirectory) {
-        try (var stream = Files.list(parentDirectory)) {
-            return stream
-                    .filter(file -> Files.isDirectory(file) && Version.parseVersion(file.getFileName().toString()) != null)
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            LOG.debug("Error listing download directory entries: " + parentDirectory, e);
-            return Collections.emptyList();
-        }
-    }
-
+    /**
+     * Returns the path where a specific version of the binary is cached.
+     * Binaries are stored flat in the shared cache directory with the version embedded in the filename,
+     * matching the layout used by the VSCode AppMap extension.
+     */
     public static @NotNull Path getExecutableFilePath(@NotNull CliTool type,
-                                               @NotNull String version,
-                                               @NotNull String platform,
-                                               @NotNull String arch,
-                                               boolean unitTestMode) {
-        return getVersionDownloadDirectory(type, version, unitTestMode).resolve(type.getBinaryName(platform, arch));
+                                                      @NotNull String version,
+                                                      @NotNull String platform,
+                                                      @NotNull String arch,
+                                                      boolean unitTestMode) {
+        return getCacheDirectory(unitTestMode).resolve(type.getBinaryName(platform, arch, version));
     }
 
-    public static @NotNull Path getVersionDownloadDirectory(@NotNull CliTool type, @NotNull String version, boolean unitTestMode) {
-        return getToolDownloadDirectory(type, unitTestMode).resolve(version);
-    }
-
+    /**
+     * Returns a per-tool subdirectory of the cache used for plugin-specific metadata (e.g. active-version.txt).
+     */
     public static @NotNull Path getToolDownloadDirectory(@NotNull CliTool type, boolean unitTestMode) {
-        var basePath = unitTestMode || "true".equals(System.getProperty("appmap.sandbox"))
-                ? Paths.get(PathManager.getTempPath()).resolve("appland-downloads")
-                : Paths.get(PathManager.getDefaultSystemPathFor("appland-plugin"));
-        return basePath.resolve(type.getId());
+        return getCacheDirectory(unitTestMode).resolve(type.getId());
     }
 }

--- a/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
+++ b/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.Version;
-import com.intellij.openapi.util.io.NioFiles;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -106,28 +105,6 @@ public final class LocalAssetRepository {
             LOG.debug("Error listing download directory entries: " + parentDirectory, e);
             return Collections.emptyList();
         }
-    }
-
-    public static void removeOtherVersions(@NotNull CliTool type, @NotNull String keepVersion, boolean unitTestMode) {
-        removeOtherVersions(getToolDownloadDirectory(type, unitTestMode), keepVersion);
-    }
-
-    public static @NotNull List<Path> removeOtherVersions(@NotNull Path directory, @NotNull String keepVersion) {
-        var toRemove = findVersionDownloadDirectories(directory)
-                .stream()
-                .filter(path -> !keepVersion.equals(path.getFileName().toString()))
-                .collect(Collectors.toList());
-
-        if (!toRemove.isEmpty()) {
-            for (var path : toRemove) {
-                try {
-                    NioFiles.deleteRecursively(path);
-                } catch (IOException e) {
-                    LOG.debug("Error deleting download directory: " + path, e);
-                }
-            }
-        }
-        return toRemove;
     }
 
     public static @NotNull Path getExecutableFilePath(@NotNull CliTool type,

--- a/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
+++ b/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
@@ -1,0 +1,104 @@
+package appland.cli;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.PathManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.Version;
+import com.intellij.openapi.util.io.NioFiles;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class LocalAssetRepository {
+    private static final Logger LOG = Logger.getInstance(LocalAssetRepository.class);
+
+    private LocalAssetRepository() {
+    }
+
+    public static @Nullable String findLatestDownloadedVersion(@NotNull CliTool type) {
+        var directory = getToolDownloadDirectory(type, ApplicationManager.getApplication().isUnitTestMode());
+        if (!Files.isDirectory(directory)) {
+            return null;
+        }
+
+        var candidates = findVersionDownloadDirectories(directory);
+        if (candidates.isEmpty()) {
+            return null;
+        }
+
+        return candidates
+                .stream()
+                .map(file -> file.getFileName().toString())
+                .max(Comparator.naturalOrder())
+                .orElse(null);
+    }
+
+    public static boolean isDownloaded(@NotNull CliTool type, @NotNull String version, @NotNull String platform, @NotNull String arch, boolean unitTestMode) {
+        return isExecutableBinary(getExecutableFilePath(type, version, platform, arch, unitTestMode));
+    }
+
+    public static boolean isExecutableBinary(@NotNull Path file) {
+        return Files.isRegularFile(file) && (!SystemInfo.isUnix || Files.isExecutable(file));
+    }
+
+    public static @NotNull List<Path> findVersionDownloadDirectories(@NotNull Path parentDirectory) {
+        try (var stream = Files.list(parentDirectory)) {
+            return stream
+                    .filter(file -> Files.isDirectory(file) && Version.parseVersion(file.getFileName().toString()) != null)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            LOG.debug("Error listing download directory entries: " + parentDirectory, e);
+            return Collections.emptyList();
+        }
+    }
+
+    public static void removeOtherVersions(@NotNull CliTool type, @NotNull String keepVersion, boolean unitTestMode) {
+        removeOtherVersions(getToolDownloadDirectory(type, unitTestMode), keepVersion);
+    }
+
+    public static @NotNull List<Path> removeOtherVersions(@NotNull Path directory, @NotNull String keepVersion) {
+        var toRemove = findVersionDownloadDirectories(directory)
+                .stream()
+                .filter(path -> !keepVersion.equals(path.getFileName().toString()))
+                .collect(Collectors.toList());
+
+        if (!toRemove.isEmpty()) {
+            for (var path : toRemove) {
+                try {
+                    NioFiles.deleteRecursively(path);
+                } catch (IOException e) {
+                    LOG.debug("Error deleting download directory: " + path, e);
+                }
+            }
+        }
+        return toRemove;
+    }
+
+    public static @NotNull Path getExecutableFilePath(@NotNull CliTool type,
+                                               @NotNull String version,
+                                               @NotNull String platform,
+                                               @NotNull String arch,
+                                               boolean unitTestMode) {
+        return getVersionDownloadDirectory(type, version, unitTestMode).resolve(type.getBinaryName(platform, arch));
+    }
+
+    public static @NotNull Path getVersionDownloadDirectory(@NotNull CliTool type, @NotNull String version, boolean unitTestMode) {
+        return getToolDownloadDirectory(type, unitTestMode).resolve(version);
+    }
+
+    public static @NotNull Path getToolDownloadDirectory(@NotNull CliTool type, boolean unitTestMode) {
+        var basePath = unitTestMode || "true".equals(System.getProperty("appmap.sandbox"))
+                ? Paths.get(PathManager.getTempPath()).resolve("appland-downloads")
+                : Paths.get(PathManager.getDefaultSystemPathFor("appland-plugin"));
+        return basePath.resolve(type.getId());
+    }
+}

--- a/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
+++ b/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
@@ -4,14 +4,16 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.openapi.util.Version;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import com.intellij.util.text.SemVer;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
 
 public final class LocalAssetRepository {
@@ -20,14 +22,16 @@ public final class LocalAssetRepository {
     private LocalAssetRepository() {
     }
 
-    private static final String ACTIVE_VERSION_FILE = "active-version.txt";
+    private static boolean isSandboxOrTestMode(boolean unitTestMode) {
+        return unitTestMode || "true".equals(System.getProperty("appmap.sandbox"));
+    }
 
     /**
      * Returns the platform-specific cache directory for downloaded CLI binaries.
      * Matches the location used by the VSCode AppMap extension so both plugins share cached downloads.
      */
     public static @NotNull Path getCacheDirectory(boolean unitTestMode) {
-        if (unitTestMode || "true".equals(System.getProperty("appmap.sandbox"))) {
+        if (isSandboxOrTestMode(unitTestMode)) {
             return Paths.get(PathManager.getTempPath()).resolve("appland-downloads");
         }
         var home = Paths.get(System.getProperty("user.home"));
@@ -46,76 +50,174 @@ public final class LocalAssetRepository {
         }
     }
 
-    public static @Nullable String getActiveVersion(@NotNull CliTool type, boolean unitTestMode) {
-        var directory = getToolDownloadDirectory(type, unitTestMode);
-        var activeVersionFile = directory.resolve(ACTIVE_VERSION_FILE);
-        if (Files.isRegularFile(activeVersionFile)) {
-            try {
-                var version = Files.readString(activeVersionFile).trim();
-                if (!version.isEmpty()) {
-                    return version;
-                }
-            } catch (IOException e) {
-                LOG.debug("Error reading active version file: " + activeVersionFile, e);
-            }
+    /**
+     * Returns the directory that holds current-version symlinks.
+     * In production: ~/.appmap/bin (matching the VSCode AppMap extension).
+     * In test/sandbox mode: a sandboxed temp directory to avoid polluting the real bin dir.
+     */
+    public static @NotNull Path getBinDirectory() {
+        if (isSandboxOrTestMode(ApplicationManager.getApplication().isUnitTestMode())) {
+            return Paths.get(PathManager.getTempPath()).resolve("appland-bin");
         }
-        return null;
+        return Paths.get(System.getProperty("user.home"), ".appmap", "bin");
     }
 
-    public static void setActiveVersion(@NotNull CliTool type, @NotNull String version, boolean unitTestMode) {
-        var directory = getToolDownloadDirectory(type, unitTestMode);
+    /**
+     * Returns the path of the current-version symlink (or Windows copy fallback) for the given tool,
+     * e.g. ~/.appmap/bin/appmap on Unix or ~/.appmap/bin/appmap.exe on Windows.
+     */
+    public static @NotNull Path getSymlinkPath(@NotNull CliTool type) {
+        var name = type.getId() + (SystemInfo.isWindows ? ".exe" : "");
+        return getBinDirectory().resolve(name);
+    }
+
+    /**
+     * Creates or updates the symlink at {@code symlinkPath} pointing to {@code cachedPath}.
+     * Falls back to copying the file on systems where symlinks are not supported (e.g. locked-down Windows).
+     */
+    public static void updateSymlink(@NotNull Path cachedPath, @NotNull Path symlinkPath) {
         try {
-            Files.createDirectories(directory);
-            Files.writeString(directory.resolve(ACTIVE_VERSION_FILE), version);
+            Files.deleteIfExists(symlinkPath);
         } catch (IOException e) {
-            LOG.warn("Failed to write active version file for " + type, e);
+            LOG.debug("Error removing existing symlink: " + symlinkPath, e);
+        }
+        try {
+            Files.createDirectories(symlinkPath.getParent());
+        } catch (IOException e) {
+            LOG.warn("Failed to create bin directory: " + symlinkPath.getParent(), e);
+            return;
+        }
+        try {
+            Files.createSymbolicLink(symlinkPath, cachedPath);
+        } catch (IOException | UnsupportedOperationException | SecurityException e) {
+            // Fallback: copy the file (e.g. Windows without symlink privileges)
+            try {
+                Files.copy(cachedPath, symlinkPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+                CliTools.fixBinaryPermissions(symlinkPath);
+            } catch (IOException ex) {
+                LOG.warn("Failed to create symlink or copy binary at " + symlinkPath, ex);
+            }
         }
     }
 
     /**
-     * @return The active version if its binary exists on disk, or the highest available fallback version.
+     * @return true if the symlink already points to {@code targetPath}, or if it is a regular file
+     * (Windows copy fallback — treat as correct to avoid redundant re-copies on steady-state runs).
      */
-    public static @Nullable String getInstalledVersion(@NotNull CliTool type) {
-        var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
-        var platform = CliPlatform.currentPlatform();
-        var arch = CliPlatform.currentArch();
-
-        var activeVersion = getActiveVersion(type, unitTestMode);
-        if (activeVersion != null && isDownloaded(type, activeVersion, platform, arch, unitTestMode)) {
-            return activeVersion;
+    public static boolean symlinkPointsTo(@NotNull Path symlinkPath, @NotNull Path targetPath) {
+        try {
+            if (Files.isSymbolicLink(symlinkPath)) {
+                var link = Files.readSymbolicLink(symlinkPath);
+                return targetPath.equals(symlinkPath.getParent().resolve(link));
+            }
+            return Files.isRegularFile(symlinkPath);
+        } catch (IOException e) {
+            return false;
         }
-
-        return findHighestCachedVersion(type, platform, arch, unitTestMode);
     }
 
-    private static @Nullable String findHighestCachedVersion(@NotNull CliTool type,
-                                                             @NotNull String platform,
-                                                             @NotNull String arch,
-                                                             boolean unitTestMode) {
+    /**
+     * Extracts the version from a bundled binary filename by splitting on the last '-'.
+     * e.g. "appmap-linux-x64-v1.2.3" → "1.2.3"
+     * Does NOT handle prerelease versions (e.g. "1.2.3-rc.1") — use
+     * {@link #versionFromCachedFilename} for downloaded cache files where the prefix is known.
+     */
+    public static @Nullable String versionFromPath(@NotNull Path path) {
+        var filename = path.getFileName().toString();
+        if (filename.endsWith(".exe")) {
+            filename = filename.substring(0, filename.length() - 4);
+        }
+        var lastDash = filename.lastIndexOf('-');
+        if (lastDash < 0) return null;
+        var after = filename.substring(lastDash + 1);
+        // Tolerate an optional leading "v" (e.g. bundled binaries with v1.2.3 suffix)
+        if (after.startsWith("v")) after = after.substring(1);
+        return (!after.isEmpty() && Character.isDigit(after.charAt(0))) ? after : null;
+    }
+
+    /**
+     * Extracts the version from a cached binary filename by stripping the known prefix.
+     * Unlike {@link #versionFromPath}, this correctly handles prerelease versions
+     * (e.g. "appmap-linux-x64-1.2.3-rc.1" → "1.2.3-rc.1").
+     */
+    private static @Nullable String versionFromCachedFilename(@NotNull String filename, @NotNull String prefix) {
+        if (filename.endsWith(".exe")) {
+            filename = filename.substring(0, filename.length() - 4);
+        }
+        if (!filename.startsWith(prefix)) return null;
+        var version = filename.substring(prefix.length());
+        if (version.startsWith("v")) version = version.substring(1);
+        return (!version.isEmpty() && Character.isDigit(version.charAt(0))) ? version : null;
+    }
+
+    /**
+     * Returns the installed version by reading the symlink target.
+     * Returns null if not installed or if the version cannot be determined (e.g. Windows copy fallback).
+     */
+    public static @Nullable String getInstalledVersion(@NotNull CliTool type) {
+        var symlinkPath = getSymlinkPath(type);
+        if (Files.isSymbolicLink(symlinkPath)) {
+            try {
+                var target = Files.readSymbolicLink(symlinkPath);
+                var filename = symlinkPath.getParent().resolve(target).getFileName().toString();
+                var prefix = type.getId() + "-" + CliPlatform.currentPlatform() + "-" + CliPlatform.currentArch() + "-";
+                return versionFromCachedFilename(filename, prefix);
+            } catch (IOException e) {
+                LOG.debug("Error reading symlink for version: " + symlinkPath, e);
+            }
+        }
+        // Not a symlink (Windows copy fallback) or read failed: version unknown
+        return null;
+    }
+
+    /**
+     * Returns the symlink (or copy) path for the tool if it exists and is executable, null otherwise.
+     * isExecutableBinary follows symlinks, so this works for both symlinks and Windows copy fallbacks.
+     */
+    public static @Nullable Path getInstalledBinaryPath(@NotNull CliTool type) {
+        var symlinkPath = getSymlinkPath(type);
+        return isExecutableBinary(symlinkPath) ? symlinkPath : null;
+    }
+
+    /**
+     * Resolves a symlink to its target so the version embedded in the target filename can be
+     * used for comparison. Returns the path as-is if it is not a symlink.
+     */
+    public static @Nullable Path resolveForVersionComparison(@Nullable Path path) {
+        if (path == null) return null;
+        if (Files.isSymbolicLink(path)) {
+            try {
+                return path.toRealPath();
+            } catch (IOException e) {
+                LOG.debug("Error resolving symlink for version comparison: " + path, e);
+            }
+        }
+        return path;
+    }
+
+    /**
+     * Returns the highest-version executable binary in the cache for the given tool/platform/arch,
+     * or null if none is found. Used to restore the symlink when the manifest is unreachable.
+     */
+    public static @Nullable Path findHighestCachedBinary(@NotNull CliTool type,
+                                                          @NotNull String platform,
+                                                          @NotNull String arch,
+                                                          boolean unitTestMode) {
         var cacheDir = getCacheDirectory(unitTestMode);
         var prefix = type.getId() + "-" + platform + "-" + arch + "-";
         try (var stream = Files.list(cacheDir)) {
             return stream
-                    .filter(p -> isExecutableBinary(p))
-                    .map(p -> p.getFileName().toString())
-                    .filter(name -> name.startsWith(prefix))
-                    .map(name -> {
-                        var stripped = name.endsWith(".exe") ? name.substring(0, name.length() - 4) : name;
-                        return stripped.substring(prefix.length());
-                    })
-                    .filter(v -> !v.isEmpty() && Version.parseVersion(v) != null)
-                    .max(Comparator.naturalOrder())
+                    .filter(LocalAssetRepository::isExecutableBinary)
+                    .filter(p -> p.getFileName().toString().startsWith(prefix))
+                    .max(Comparator.comparing(p -> {
+                        var v = versionFromCachedFilename(p.getFileName().toString(), prefix);
+                        return v != null ? SemVer.parseFromText(v) : null;
+                    }, SemVerComparator.INSTANCE))
                     .orElse(null);
         } catch (IOException e) {
-            LOG.debug("Error scanning cache directory: " + cacheDir, e);
+            LOG.debug("Error scanning cache directory for fallback binary: " + cacheDir, e);
             return null;
         }
-    }
-
-    public static @Nullable Path getInstalledBinaryPath(@NotNull CliTool type, @NotNull String platform, @NotNull String arch) {
-        var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
-        var version = getInstalledVersion(type);
-        return version != null ? getExecutableFilePath(type, version, platform, arch, unitTestMode) : null;
     }
 
     public static boolean isDownloaded(@NotNull CliTool type, @NotNull String version, @NotNull String platform, @NotNull String arch, boolean unitTestMode) {
@@ -140,9 +242,9 @@ public final class LocalAssetRepository {
     }
 
     /**
-     * Returns a per-tool subdirectory of the cache used for plugin-specific metadata (e.g. active-version.txt).
+     * Returns the cache directory for the given tool (both tools share the same flat cache directory).
      */
     public static @NotNull Path getToolDownloadDirectory(@NotNull CliTool type, boolean unitTestMode) {
-        return getCacheDirectory(unitTestMode).resolve(type.getId());
+        return getCacheDirectory(unitTestMode);
     }
 }

--- a/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
+++ b/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
@@ -24,10 +24,47 @@ public final class LocalAssetRepository {
     private LocalAssetRepository() {
     }
 
-    public static @Nullable String findLatestDownloadedVersion(@NotNull CliTool type) {
-        var directory = getToolDownloadDirectory(type, ApplicationManager.getApplication().isUnitTestMode());
+    private static final String ACTIVE_VERSION_FILE = "active-version.txt";
+
+    public static @Nullable String getActiveVersion(@NotNull CliTool type, boolean unitTestMode) {
+        var directory = getToolDownloadDirectory(type, unitTestMode);
+        var activeVersionFile = directory.resolve(ACTIVE_VERSION_FILE);
+        if (Files.isRegularFile(activeVersionFile)) {
+            try {
+                var version = Files.readString(activeVersionFile).trim();
+                if (!version.isEmpty()) {
+                    return version;
+                }
+            } catch (IOException e) {
+                LOG.debug("Error reading active version file: " + activeVersionFile, e);
+            }
+        }
+        return null;
+    }
+
+    public static void setActiveVersion(@NotNull CliTool type, @NotNull String version, boolean unitTestMode) {
+        var directory = getToolDownloadDirectory(type, unitTestMode);
+        try {
+            Files.createDirectories(directory);
+            Files.writeString(directory.resolve(ACTIVE_VERSION_FILE), version);
+        } catch (IOException e) {
+            LOG.warn("Failed to write active version file for " + type, e);
+        }
+    }
+
+    /**
+     * @return The active version if its binary exists on disk, or the highest available fallback version.
+     */
+    public static @Nullable String getInstalledVersion(@NotNull CliTool type) {
+        var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
+        var directory = getToolDownloadDirectory(type, unitTestMode);
         if (!Files.isDirectory(directory)) {
             return null;
+        }
+
+        var activeVersion = getActiveVersion(type, unitTestMode);
+        if (activeVersion != null && isDownloaded(type, activeVersion, CliPlatform.currentPlatform(), CliPlatform.currentArch(), unitTestMode)) {
+            return activeVersion;
         }
 
         var candidates = findVersionDownloadDirectories(directory);
@@ -35,11 +72,21 @@ public final class LocalAssetRepository {
             return null;
         }
 
+        var platform = CliPlatform.currentPlatform();
+        var arch = CliPlatform.currentArch();
+
         return candidates
                 .stream()
                 .map(file -> file.getFileName().toString())
+                .filter(v -> isDownloaded(type, v, platform, arch, unitTestMode))
                 .max(Comparator.naturalOrder())
                 .orElse(null);
+    }
+
+    public static @Nullable Path getInstalledBinaryPath(@NotNull CliTool type, @NotNull String platform, @NotNull String arch) {
+        var unitTestMode = ApplicationManager.getApplication().isUnitTestMode();
+        var version = getInstalledVersion(type);
+        return version != null ? getExecutableFilePath(type, version, platform, arch, unitTestMode) : null;
     }
 
     public static boolean isDownloaded(@NotNull CliTool type, @NotNull String version, @NotNull String platform, @NotNull String arch, boolean unitTestMode) {

--- a/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
+++ b/plugin-core/src/main/java/appland/cli/LocalAssetRepository.java
@@ -29,9 +29,18 @@ public final class LocalAssetRepository {
     /**
      * Returns the platform-specific cache directory for downloaded CLI binaries.
      * Matches the location used by the VSCode AppMap extension so both plugins share cached downloads.
+     * In unit-test mode a stable per-user directory is used so downloaded binaries survive across
+     * test invocations and only need to be fetched once per version per machine.
      */
     public static @NotNull Path getCacheDirectory(boolean unitTestMode) {
-        if (isSandboxOrTestMode(unitTestMode)) {
+        if (unitTestMode) {
+            var xdgCacheHome = System.getenv("XDG_CACHE_HOME");
+            var cacheBase = xdgCacheHome != null
+                    ? Paths.get(xdgCacheHome)
+                    : Paths.get(System.getProperty("user.home"), ".cache");
+            return cacheBase.resolve("appmap-test");
+        }
+        if ("true".equals(System.getProperty("appmap.sandbox"))) {
             return Paths.get(PathManager.getTempPath()).resolve("appland-downloads");
         }
         var home = Paths.get(System.getProperty("user.home"));
@@ -54,6 +63,9 @@ public final class LocalAssetRepository {
      * Returns the directory that holds current-version symlinks.
      * In production: ~/.appmap/bin (matching the VSCode AppMap extension).
      * In test/sandbox mode: a sandboxed temp directory to avoid polluting the real bin dir.
+     * Note: unlike getCacheDirectory, this intentionally uses the combined sandbox+unitTest check
+     * because the bin dir must always be ephemeral in both modes — tests call removeDownloads() to
+     * reset symlink state between runs, and runIde sandbox must not touch the real ~/.appmap/bin.
      */
     public static @NotNull Path getBinDirectory() {
         if (isSandboxOrTestMode(ApplicationManager.getApplication().isUnitTestMode())) {
@@ -203,7 +215,17 @@ public final class LocalAssetRepository {
                                                           @NotNull String platform,
                                                           @NotNull String arch,
                                                           boolean unitTestMode) {
-        var cacheDir = getCacheDirectory(unitTestMode);
+        return findHighestCachedBinaryIn(type, platform, arch, getCacheDirectory(unitTestMode));
+    }
+
+    /**
+     * Like {@link #findHighestCachedBinary} but searches an explicit directory.
+     * Used by tests that need an isolated cache dir so they don't pollute the shared test cache.
+     */
+    static @Nullable Path findHighestCachedBinaryIn(@NotNull CliTool type,
+                                                     @NotNull String platform,
+                                                     @NotNull String arch,
+                                                     @NotNull Path cacheDir) {
         var prefix = type.getId() + "-" + platform + "-" + arch + "-";
         try (var stream = Files.list(cacheDir)) {
             return stream

--- a/plugin-core/src/main/java/appland/cli/Manifest.java
+++ b/plugin-core/src/main/java/appland/cli/Manifest.java
@@ -1,0 +1,88 @@
+package appland.cli;
+
+import appland.utils.GsonUtils;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class Manifest {
+    private static final Logger LOG = Logger.getInstance(Manifest.class);
+
+    // Captures the platform identifier suffix of a manifest asset name, e.g.
+    // `scanner-linux-x64`, `scanner-macos-arm64`, `scanner-win-x64.exe`. Anchored
+    // so an unrelated trailing token won't be silently bucketed alongside the canonical asset.
+    // The capture group excludes any `.exe` suffix so Windows and non-Windows entries share a key shape.
+    private static final Pattern PLATFORM_IN_ASSET_NAME = Pattern.compile("((?:linux|macos|win)-(?:x64|arm64))(?:\\.exe)?$");
+    private static final Pattern TAG_VERSION_PATTERN = Pattern.compile("v(\\d+\\.\\d+\\.\\d+[\\w.+-]*)$");
+
+    public final @NotNull String version;
+    private final @NotNull Map<String, ManifestAsset> assetsByPlatform;
+
+    private Manifest(@NotNull String version, @NotNull Map<String, ManifestAsset> assetsByPlatform) {
+        this.version = version;
+        this.assetsByPlatform = assetsByPlatform;
+    }
+
+    public static @Nullable Manifest parse(@NotNull String rawJson) {
+        try {
+            var element = GsonUtils.GSON.fromJson(rawJson, JsonObject.class);
+            if (element == null || !element.isJsonObject()) {
+                LOG.warn("Manifest is not a JSON object");
+                return null;
+            }
+            var obj = element.getAsJsonObject();
+
+            if (!obj.has("tag_name") || !obj.get("tag_name").isJsonPrimitive()) {
+                LOG.warn("Manifest tag_name is missing or not a string");
+                return null;
+            }
+
+            var tagName = obj.getAsJsonPrimitive("tag_name").getAsString();
+            var match = TAG_VERSION_PATTERN.matcher(tagName);
+            if (!match.find()) {
+                LOG.warn("Could not parse manifest version from tag " + tagName);
+                return null;
+            }
+            var version = match.group(1);
+
+            if (!obj.has("assets") || !obj.get("assets").isJsonArray()) {
+                LOG.warn("Manifest assets is missing or not an array");
+                return null;
+            }
+
+            var assetsByPlatform = new HashMap<String, ManifestAsset>();
+            for (var entryElement : obj.getAsJsonArray("assets")) {
+                if (!entryElement.isJsonObject()) continue;
+                var asset = entryElement.getAsJsonObject();
+
+                if (!asset.has("name") || !asset.get("name").isJsonPrimitive()
+                        || !asset.has("url") || !asset.get("url").isJsonPrimitive()) continue;
+                var name = asset.getAsJsonPrimitive("name").getAsString();
+                var url = asset.getAsJsonPrimitive("url").getAsString();
+                
+                var digest = asset.has("digest") && asset.get("digest").isJsonPrimitive() 
+                        ? asset.getAsJsonPrimitive("digest").getAsString() 
+                        : null;
+
+                var platformMatch = PLATFORM_IN_ASSET_NAME.matcher(name);
+                if (platformMatch.find()) {
+                    assetsByPlatform.put(platformMatch.group(1), new ManifestAsset(url, digest));
+                }
+            }
+
+            return new Manifest(version, Map.copyOf(assetsByPlatform));
+        } catch (RuntimeException e) {
+            LOG.warn("Failed to parse manifest JSON", e);
+            return null;
+        }
+    }
+
+    public @Nullable ManifestAsset getAsset(@NotNull String platformId) {
+        return assetsByPlatform.get(platformId);
+    }
+}

--- a/plugin-core/src/main/java/appland/cli/ManifestAsset.java
+++ b/plugin-core/src/main/java/appland/cli/ManifestAsset.java
@@ -1,0 +1,11 @@
+package appland.cli;
+
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Value
+public class ManifestAsset {
+    public @NotNull String url;
+    public @Nullable String digest;
+}

--- a/plugin-core/src/main/java/appland/cli/ManifestManager.java
+++ b/plugin-core/src/main/java/appland/cli/ManifestManager.java
@@ -37,7 +37,7 @@ public final class ManifestManager {
             }
             
             return manifest;
-        } catch (IOException e) {
+        } catch (Exception e) {
             LOG.warn("Failed to fetch manifest from " + urlString + ": " + e.toString());
             // Don't cache failures so a transient outage doesn't disable discovery until restart
             return null;

--- a/plugin-core/src/main/java/appland/cli/ManifestManager.java
+++ b/plugin-core/src/main/java/appland/cli/ManifestManager.java
@@ -1,0 +1,50 @@
+package appland.cli;
+
+import appland.settings.DownloadSettings;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.util.Urls;
+import com.intellij.util.io.HttpRequests;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class ManifestManager {
+    private static final Logger LOG = Logger.getInstance(ManifestManager.class);
+    private static final Map<String, Manifest> CACHE = new ConcurrentHashMap<>();
+
+    private ManifestManager() {
+    }
+
+    public static @Nullable Manifest fetch(@NotNull CliTool type) {
+        return fetch(DownloadSettings.getManifestUrl(type));
+    }
+
+    public static @Nullable Manifest fetch(@NotNull String urlString) {
+        var cached = CACHE.get(urlString);
+        if (cached != null) return cached;
+
+        try {
+            var url = Urls.newFromEncoded(urlString);
+            var jsonString = HttpRequests.request(url).readString(null);
+            var manifest = Manifest.parse(jsonString);
+            
+            if (manifest != null) {
+                LOG.info("Fetched manifest from " + urlString + " (version " + manifest.version + ")");
+                CACHE.put(urlString, manifest);
+            }
+            
+            return manifest;
+        } catch (IOException e) {
+            LOG.warn("Failed to fetch manifest from " + urlString + ": " + e.toString());
+            // Don't cache failures so a transient outage doesn't disable discovery until restart
+            return null;
+        }
+    }
+
+    public static void clearCache() {
+        CACHE.clear();
+    }
+}

--- a/plugin-core/src/main/java/appland/cli/SemVerComparator.java
+++ b/plugin-core/src/main/java/appland/cli/SemVerComparator.java
@@ -10,10 +10,10 @@ public final class SemVerComparator implements Comparator<@Nullable SemVer> {
 
     @Override
     public int compare(@Nullable SemVer o1, @Nullable SemVer o2) {
-        // sort null to the end
+        // sort null to the beginning (smaller than any valid SemVer)
         if (o1 == null && o2 == null) return 0;
-        if (o1 == null) return 1;
-        if (o2 == null) return -1;
+        if (o1 == null) return -1;
+        if (o2 == null) return 1;
 
         return o1.compareTo(o2);
     }

--- a/plugin-core/src/main/java/appland/cli/StartServicesAfterDownloadListener.java
+++ b/plugin-core/src/main/java/appland/cli/StartServicesAfterDownloadListener.java
@@ -16,7 +16,7 @@ public class StartServicesAfterDownloadListener implements AppLandDownloadListen
         }
 
         if (CliTools.isBinaryAvailable(CliTool.AppMap) && CliTools.isBinaryAvailable(CliTool.Scanner)) {
-            AppLandCommandLineService.getInstance().refreshForOpenProjectsInBackground();
+            AppLandCommandLineService.getInstance().restartProcessesInBackground();
         }
     }
 }

--- a/plugin-core/src/main/java/appland/deployment/AppMapDeploymentSettings.java
+++ b/plugin-core/src/main/java/appland/deployment/AppMapDeploymentSettings.java
@@ -17,12 +17,20 @@ public final class AppMapDeploymentSettings {
     @SerializedName("appMap.autoUpdateTools")
     private boolean autoUpdateTools = true;
 
+    @SerializedName("appMap.manifest.appmapUrl")
+    @Nullable
+    private String appmapManifestUrl;
+
+    @SerializedName("appMap.manifest.scannerUrl")
+    @Nullable
+    private String scannerManifestUrl;
+
     public AppMapDeploymentSettings(@Nullable AppMapDeploymentTelemetrySettings telemetry) {
-        this(telemetry, true);
+        this(telemetry, true, null, null);
     }
 
     public boolean isEmpty() {
-        return this.telemetry == null && autoUpdateTools;
+        return this.telemetry == null && autoUpdateTools && appmapManifestUrl == null && scannerManifestUrl == null;
     }
 }
 

--- a/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
+++ b/plugin-core/src/main/java/appland/rpcService/DefaultAppLandJsonRpcService.java
@@ -235,6 +235,8 @@ public class DefaultAppLandJsonRpcService implements AppLandJsonRpcService, AppL
 
         commandLine = commandLine.withEnvironment("APPMAP_CODE_EDITOR", createCodeEditorInfo());
 
+        LOG.info("Starting AppMap JSON-RPC server using binary: " + commandLine.getExePath());
+
         KillableProcessHandler process;
         try {
             synchronized (this) {

--- a/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapApplicationSettings.java
@@ -70,6 +70,9 @@ public class AppMapApplicationSettings {
 
     private volatile boolean showFailedCliDownloadError = true;
 
+    private volatile @Nullable String appmapManifestUrl = null;
+    private volatile @Nullable String scannerManifestUrl = null;
+
     private volatile @Nullable String selectedAppMapModel = null;
 
     /**
@@ -106,6 +109,8 @@ public class AppMapApplicationSettings {
         this.copilotIntegrationDetected = settings.copilotIntegrationDetected;
         this.copilotModelId = settings.copilotModelId;
         this.showFailedCliDownloadError = settings.showFailedCliDownloadError;
+        this.appmapManifestUrl = settings.appmapManifestUrl;
+        this.scannerManifestUrl = settings.scannerManifestUrl;
         this.selectedAppMapModel = settings.selectedAppMapModel;
         this.modelConfig.putAll(settings.modelConfig);
         this.autoUpdateTools = settings.autoUpdateTools;
@@ -223,6 +228,24 @@ public class AppMapApplicationSettings {
     public void setAutoUpdateToolsNotifying(@Nullable Boolean autoUpdateTools) {
         var changed = !Objects.equals(autoUpdateTools, this.autoUpdateTools);
         this.autoUpdateTools = autoUpdateTools;
+
+        if (changed) {
+            settingsPublisher().autoUpdateToolsChanged();
+        }
+    }
+
+    public void setAppmapManifestUrlNotifying(@Nullable String appmapManifestUrl) {
+        var changed = !Objects.equals(appmapManifestUrl, this.appmapManifestUrl);
+        this.appmapManifestUrl = appmapManifestUrl;
+
+        if (changed) {
+            settingsPublisher().autoUpdateToolsChanged();
+        }
+    }
+
+    public void setScannerManifestUrlNotifying(@Nullable String scannerManifestUrl) {
+        var changed = !Objects.equals(scannerManifestUrl, this.scannerManifestUrl);
+        this.scannerManifestUrl = scannerManifestUrl;
 
         if (changed) {
             settingsPublisher().autoUpdateToolsChanged();

--- a/plugin-core/src/main/java/appland/settings/AppMapSettingsReloadProjectListener.java
+++ b/plugin-core/src/main/java/appland/settings/AppMapSettingsReloadProjectListener.java
@@ -3,6 +3,7 @@ package appland.settings;
 import appland.AppLandLifecycleService;
 import appland.notifications.AppMapNotifications;
 import appland.rpcService.AppLandJsonRpcService;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.ProjectManager;
@@ -17,30 +18,38 @@ import java.util.Set;
  * Displays a notification in each of the opened projects to reload the project after settings changed,
  * which require a project reload to activate.
  */
+// applicationListeners subscribers must not implement Disposable (JetBrains guidelines). We still
+// need alarms scoped tighter than the application: using AppLandLifecycleService directly causes
+// cross-test state leaks when alarms fire after a test finishes and trigger unexpected restarts in
+// the next one. The package-private constructor lets tests inject getTestRootDisposable() instead.
 public class AppMapSettingsReloadProjectListener implements AppMapSettingsListener {
     // Debounce the notification, because several separate settings may be changed at once.
     // Initialized lazily, because init references a service and other services
     // must not be accessed during initialization in 2025.1+.
-    private final LazyInitializer.LazyValue<SingleAlarm> showReloadNotificationAlarm = LazyInitializer.create(() -> {
-        return new SingleAlarm(
+    private final LazyInitializer.LazyValue<SingleAlarm> showReloadNotificationAlarm;
+    private final LazyInitializer.LazyValue<SingleAlarm> reloadJsonRpcServerAlarm;
+
+    @SuppressWarnings("unused") // instantiated by the platform via XML applicationListeners registration
+    public AppMapSettingsReloadProjectListener() {
+        this(AppLandLifecycleService.getInstance());
+    }
+
+    @org.jetbrains.annotations.TestOnly
+    @SuppressWarnings("deprecation") // SingleAlarm is deprecated in favour of Flow.debounce, which is Kotlin-only
+    public AppMapSettingsReloadProjectListener(@NotNull Disposable alarmParent) {
+        showReloadNotificationAlarm = LazyInitializer.create(() -> new SingleAlarm(
                 this::showReloadNotificationInAllProjects,
                 1_000,
-                AppLandLifecycleService.getInstance(),
+                alarmParent,
                 Alarm.ThreadToUse.SWING_THREAD,
-                ModalityState.defaultModalityState());
-    });
-
-    // Debounce the notification, because several separate settings may be changed at once.
-    // Initialized lazily, because init references a service and other services
-    // must not be accessed during initialization in 2025.1+.
-    private final LazyInitializer.LazyValue<SingleAlarm> reloadJsonRpcServerAlarm = LazyInitializer.create(() -> {
-        return new SingleAlarm(
+                ModalityState.defaultModalityState()));
+        reloadJsonRpcServerAlarm = LazyInitializer.create(() -> new SingleAlarm(
                 this::restartJsonRpcServerInAllProjects,
                 1_000,
-                AppLandLifecycleService.getInstance(),
+                alarmParent,
                 Alarm.ThreadToUse.POOLED_THREAD,
-                ModalityState.defaultModalityState());
-    });
+                ModalityState.defaultModalityState()));
+    }
 
 
     @Override

--- a/plugin-core/src/main/java/appland/settings/AutoDownloadSettingsListener.java
+++ b/plugin-core/src/main/java/appland/settings/AutoDownloadSettingsListener.java
@@ -1,12 +1,11 @@
 package appland.settings;
 
 import appland.cli.AppLandDownloadService;
+import appland.cli.ManifestManager;
 import appland.javaAgent.AppMapJavaAgentDownloadService;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
-
-import java.io.IOException;
 
 public class AutoDownloadSettingsListener implements AppMapSettingsListener {
     private static final Logger LOG = Logger.getInstance(AutoDownloadSettingsListener.class);
@@ -20,11 +19,8 @@ public class AutoDownloadSettingsListener implements AppMapSettingsListener {
     @Override
     public void autoUpdateToolsChanged() {
         if (DownloadSettings.isAssetDownloadEnabled()) {
-            try {
-                AppLandDownloadService.getInstance().queueDownloadTasks(project);
-            } catch (IOException e) {
-                LOG.warn("Failed to download AppMap CLI assets", e);
-            }
+            ManifestManager.clearCache();
+            AppLandDownloadService.getInstance().queueDownloadTasks(project);
 
             try {
                 AppMapJavaAgentDownloadService.getInstance().downloadJavaAgent(project);

--- a/plugin-core/src/main/java/appland/settings/DownloadSettings.java
+++ b/plugin-core/src/main/java/appland/settings/DownloadSettings.java
@@ -1,8 +1,14 @@
 package appland.settings;
 
+import appland.cli.CliTool;
 import appland.deployment.AppMapDeploymentSettingsService;
+import com.intellij.openapi.util.text.StringUtil;
+import org.jetbrains.annotations.NotNull;
 
 public final class DownloadSettings {
+    public static final String DEFAULT_APPMAP_MANIFEST_URL = "https://raw.githubusercontent.com/getappmap/appmap-js/release-manifests/appmap-latest.json";
+    public static final String DEFAULT_SCANNER_MANIFEST_URL = "https://raw.githubusercontent.com/getappmap/appmap-js/release-manifests/scanner-latest.json";
+
     private DownloadSettings() {
     }
 
@@ -20,5 +26,30 @@ public final class DownloadSettings {
 
     public static boolean isAssetDownloadDisabled() {
         return !isAssetDownloadEnabled();
+    }
+
+    public static @NotNull String getManifestUrl(@NotNull CliTool type) {
+        var appSettings = AppMapApplicationSettingsService.getInstance();
+        var deploymentSettings = AppMapDeploymentSettingsService.getCachedDeploymentSettings();
+
+        if (type == CliTool.AppMap) {
+            var url = appSettings.getAppmapManifestUrl();
+            if (!StringUtil.isEmptyOrSpaces(url)) return url;
+            
+            url = deploymentSettings.getAppmapManifestUrl();
+            if (!StringUtil.isEmptyOrSpaces(url)) return url;
+            
+            return DEFAULT_APPMAP_MANIFEST_URL;
+        } else if (type == CliTool.Scanner) {
+            var url = appSettings.getScannerManifestUrl();
+            if (!StringUtil.isEmptyOrSpaces(url)) return url;
+            
+            url = deploymentSettings.getScannerManifestUrl();
+            if (!StringUtil.isEmptyOrSpaces(url)) return url;
+            
+            return DEFAULT_SCANNER_MANIFEST_URL;
+        }
+
+        throw new IllegalArgumentException("Unsupported CLI tool: " + type);
     }
 }

--- a/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
+++ b/plugin-core/src/main/kotlin/appland/settings/AppMapProjectSettingsPanel.kt
@@ -1,6 +1,7 @@
 package appland.settings
 
 import appland.AppMapBundle
+import appland.cli.CliTool
 import appland.deployment.AppMapDeploymentSettingsService.getCachedDeploymentSettings
 import com.intellij.execution.configuration.EnvironmentVariablesComponent
 import com.intellij.openapi.ui.ComboBox
@@ -25,6 +26,8 @@ class AppMapProjectSettingsPanel {
     private lateinit var maxPinnedFileSizeKB: JBIntSpinner
     private lateinit var openAIKey: JBTextField
     private lateinit var useAnimation: JCheckBox
+    private lateinit var appmapManifestUrl: JBTextField
+    private lateinit var scannerManifestUrl: JBTextField
 
     fun loadSettingsFrom(
         applicationSettings: AppMapApplicationSettings,
@@ -46,6 +49,9 @@ class AppMapProjectSettingsPanel {
             // with deployment settings, both true and false override the default from the deployment setting
             else -> autoUpdateTools
         }
+        
+        appmapManifestUrl.text = DownloadSettings.getManifestUrl(CliTool.AppMap)
+        scannerManifestUrl.text = DownloadSettings.getManifestUrl(CliTool.Scanner)
     }
 
     fun applySettingsTo(
@@ -78,6 +84,20 @@ class AppMapProjectSettingsPanel {
             applicationSettings.setAutoUpdateToolsNotifying(autoUpdateTools)
         } else {
             applicationSettings.autoUpdateTools = autoUpdateTools
+        }
+        
+        val defaultAppMapUrl = getCachedDeploymentSettings().appmapManifestUrl?.takeUnless { it.isBlank() } ?: DownloadSettings.DEFAULT_APPMAP_MANIFEST_URL
+        val defaultScannerUrl = getCachedDeploymentSettings().scannerManifestUrl?.takeUnless { it.isBlank() } ?: DownloadSettings.DEFAULT_SCANNER_MANIFEST_URL
+        
+        val appmapManifest = appmapManifestUrl.text.takeIf { it.isNotBlank() && it != defaultAppMapUrl }
+        val scannerManifest = scannerManifestUrl.text.takeIf { it.isNotBlank() && it != defaultScannerUrl }
+        
+        if (notify) {
+            applicationSettings.setAppmapManifestUrlNotifying(appmapManifest)
+            applicationSettings.setScannerManifestUrlNotifying(scannerManifest)
+        } else {
+            applicationSettings.appmapManifestUrl = appmapManifest
+            applicationSettings.scannerManifestUrl = scannerManifest
         }
     }
 
@@ -133,6 +153,15 @@ class AppMapProjectSettingsPanel {
                 row {
                     cell(cliEnvironment).align(AlignX.FILL)
                 }
+            }
+            group(AppMapBundle.get("projectSettings.advanced")) {
+                row(AppMapBundle.get("projectSettings.appmapManifestUrl.title")) {
+                    appmapManifestUrl = textField().align(AlignX.FILL).component
+                }.layout(RowLayout.INDEPENDENT)
+                
+                row(AppMapBundle.get("projectSettings.scannerManifestUrl.title")) {
+                    scannerManifestUrl = textField().align(AlignX.FILL).component
+                }.layout(RowLayout.INDEPENDENT)
             }
         }
     }

--- a/plugin-core/src/main/resources/messages/appland.properties
+++ b/plugin-core/src/main/resources/messages/appland.properties
@@ -323,3 +323,8 @@ notification.copilotExclusionDownloadFailed.title=AppMap Copilot Integration
 notification.copilotExclusionDownloadFailed.subtitle=Error
 notification.copilotExclusionDownloadFailed.content=Content exclusion policy download from GitHub failed:<br>{0}<br>Please try again later.
 projectSettings.automaticToolsUpdate.deploymentDefaultComment=Default: {0}
+
+projectSettings.advanced=Advanced
+projectSettings.appmapManifestUrl.title=AppMap CLI Manifest URL:
+projectSettings.scannerManifestUrl.title=Scanner CLI Manifest URL:
+projectSettings.manifestUrl.deploymentDefaultComment=Overridden by deployment setting: {0}

--- a/plugin-core/src/test/java/appland/RequiresNetwork.java
+++ b/plugin-core/src/test/java/appland/RequiresNetwork.java
@@ -1,0 +1,8 @@
+package appland;
+
+/**
+ * JUnit category for tests that require a live network connection.
+ * Excluded from the default test run; opt in with -PincludeNetworkTests.
+ */
+public final class RequiresNetwork {
+}

--- a/plugin-core/src/test/java/appland/actions/AddNavieContextFilesActionTest.java
+++ b/plugin-core/src/test/java/appland/actions/AddNavieContextFilesActionTest.java
@@ -1,6 +1,7 @@
 package appland.actions;
 
 import appland.AppMapBaseTest;
+import appland.RequiresNetwork;
 import appland.cli.TestAppLandDownloadService;
 import appland.utils.DataContexts;
 import appland.webviews.navie.NavieEditor;
@@ -20,10 +21,12 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
+@Category(RequiresNetwork.class)
 public class AddNavieContextFilesActionTest extends AppMapBaseTest {
     @Override
     protected TempDirTestFixture createTempDirTestFixture() {

--- a/plugin-core/src/test/java/appland/cli/AppLandDownloadServiceTestUtil.java
+++ b/plugin-core/src/test/java/appland/cli/AppLandDownloadServiceTestUtil.java
@@ -26,10 +26,7 @@ final class AppLandDownloadServiceTestUtil {
     static @NotNull AppMapDownloadStatus downloadLatestCliVersions(@NotNull Project project,
                                                                    @NotNull CliTool toolType,
                                                                    @NotNull Disposable parentDisposable) throws Exception {
-        var service = AppLandDownloadService.getInstance();
-
-        var latestVersion = service.fetchLatestRemoteVersion(toolType);
-        Assert.assertNotNull(latestVersion);
+        var service = (DefaultAppLandDownloadService) AppLandDownloadService.getInstance();
 
         var downloadSuccessful = new AtomicReference<AppMapDownloadStatus>();
         var downloadException = new AtomicReference<Exception>();
@@ -47,7 +44,7 @@ final class AppLandDownloadServiceTestUtil {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
                 try {
-                    service.download(toolType, latestVersion, indicator);
+                    service.download(toolType, indicator);
                 } catch (Exception e) {
                     downloadException.set(e);
                 }
@@ -70,6 +67,6 @@ final class AppLandDownloadServiceTestUtil {
                                                 @NotNull CliTool toolType,
                                                 @NotNull Disposable parentDisposable) throws Exception {
         var status = downloadLatestCliVersions(project, toolType, parentDisposable);
-        Assert.assertTrue("The download must be successful", status.isSuccessful());
+        Assert.assertNotEquals("The download must not fail", AppMapDownloadStatus.Failed, status);
     }
 }

--- a/plugin-core/src/test/java/appland/cli/CliToolTest.java
+++ b/plugin-core/src/test/java/appland/cli/CliToolTest.java
@@ -5,30 +5,6 @@ import org.junit.Test;
 
 public class CliToolTest extends AppMapBaseTest {
     @Test
-    public void urlsAppMap() {
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/appmap-v3.32.2/appmap-linux-x64",
-                CliTool.AppMap.getDownloadUrl("3.32.2", "linux", "x64"));
-
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/appmap-v3.32.2/appmap-macos-arm64",
-                CliTool.AppMap.getDownloadUrl("3.32.2", "macos", "arm64"));
-
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/appmap-v3.32.2/appmap-win-x64.exe",
-                CliTool.AppMap.getDownloadUrl("3.32.2", "win", "x64"));
-    }
-
-    @Test
-    public void urlsScanner() {
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/scanner-v1.67.0/scanner-linux-x64",
-                CliTool.Scanner.getDownloadUrl("1.67.0", "linux", "x64"));
-
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/scanner-v1.67.0/scanner-macos-arm64",
-                CliTool.Scanner.getDownloadUrl("1.67.0", "macos", "arm64"));
-
-        assertEquals("https://github.com/getappmap/appmap-js/releases/download/@appland/scanner-v1.67.0/scanner-win-x64.exe",
-                CliTool.Scanner.getDownloadUrl("1.67.0", "win", "x64"));
-    }
-
-    @Test
     public void binaryNames() {
         assertEquals("appmap-linux-x64", CliTool.AppMap.getBinaryName("linux", "x64"));
         assertEquals("appmap-macos-x64", CliTool.AppMap.getBinaryName("macos", "x64"));

--- a/plugin-core/src/test/java/appland/cli/CliToolsTest.java
+++ b/plugin-core/src/test/java/appland/cli/CliToolsTest.java
@@ -137,6 +137,37 @@ public class CliToolsTest extends AppMapBaseTest {
         assertEquals("1.2.3-rc.1", LocalAssetRepository.getInstalledVersion(CliTool.AppMap));
     }
 
+    @Test
+    public void findHighestCachedBinaryWithInvalidVersions() throws Exception {
+        var platform = CliPlatform.currentPlatform();
+        var arch = CliPlatform.currentArch();
+        var cacheDir = LocalAssetRepository.getCacheDirectory(true);
+        Files.createDirectories(cacheDir);
+
+        try (var stream = Files.list(cacheDir)) {
+            var files = stream.collect(java.util.stream.Collectors.toList());
+            for (var path : files) {
+                try {
+                    Files.delete(path);
+                } catch (java.io.IOException ignored) {
+                }
+            }
+        }
+
+        var binary123 = cacheDir.resolve(CliTool.AppMap.getBinaryName(platform, arch, "1.2.3"));
+        Files.write(binary123, new byte[0]);
+        CliTools.fixBinaryPermissions(binary123);
+
+        var binaryInvalid = cacheDir.resolve(CliTool.AppMap.getBinaryName(platform, arch, "crashing-tmp"));
+        Files.write(binaryInvalid, new byte[0]);
+        CliTools.fixBinaryPermissions(binaryInvalid);
+
+        var highest = LocalAssetRepository.findHighestCachedBinary(CliTool.AppMap, platform, arch, true);
+        assertNotNull("Should find a fallback binary", highest);
+        assertEquals("The binary with a valid SemVer should be preferred over the unparseable one",
+                binary123.toAbsolutePath(), highest.toAbsolutePath());
+    }
+
     private @NotNull Path createMockBinary(String filename) {
         return myFixture.getTempDirFixture().createFile(filename).toNioPath();
     }

--- a/plugin-core/src/test/java/appland/cli/CliToolsTest.java
+++ b/plugin-core/src/test/java/appland/cli/CliToolsTest.java
@@ -2,6 +2,7 @@ package appland.cli;
 
 import appland.AppMapBaseTest;
 import appland.AppMapDeploymentTestUtils;
+import appland.RequiresNetwork;
 import com.intellij.openapi.progress.EmptyProgressIndicator;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
@@ -9,6 +10,7 @@ import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assume;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -78,7 +80,7 @@ public class CliToolsTest extends AppMapBaseTest {
 
     @Test
     public void installedBinaryIsPreferred() throws Exception {
-        TestAppLandDownloadService.ensureDownloaded();
+        TestAppLandDownloadService.ensureStubInstalled();
 
         var installedBinary = LocalAssetRepository.getInstalledBinaryPath(CliTool.AppMap);
         assertNotNull(installedBinary);
@@ -93,6 +95,7 @@ public class CliToolsTest extends AppMapBaseTest {
         });
     }
 
+    @Category(RequiresNetwork.class)
     @Test
     public void symlinkCreatedAfterDownload() throws Exception {
         Assume.assumeFalse("symlinks are unreliable on Windows", SystemInfo.isWindows);
@@ -109,6 +112,7 @@ public class CliToolsTest extends AppMapBaseTest {
         assertNotNull("Version is readable from symlink", version);
     }
 
+    @Category(RequiresNetwork.class)
     @Test
     public void secondDownloadIsSkipped() {
         var service = (TestAppLandDownloadService) AppLandDownloadService.getInstance();
@@ -124,8 +128,8 @@ public class CliToolsTest extends AppMapBaseTest {
     public void prereleaseVersionExtractedFromSymlink() throws Exception {
         var platform = CliPlatform.currentPlatform();
         var arch = CliPlatform.currentArch();
-        var cacheDir = LocalAssetRepository.getCacheDirectory(true);
-        Files.createDirectories(cacheDir);
+        // Use the fixture temp dir so we don't pollute the shared persistent cache.
+        var cacheDir = myFixture.getTempDirFixture().createFile("prerelease-cache-placeholder").toNioPath().getParent();
 
         var binaryName = CliTool.AppMap.getBinaryName(platform, arch, "1.2.3-rc.1");
         var cachedBinary = cacheDir.resolve(binaryName);
@@ -141,18 +145,8 @@ public class CliToolsTest extends AppMapBaseTest {
     public void findHighestCachedBinaryWithInvalidVersions() throws Exception {
         var platform = CliPlatform.currentPlatform();
         var arch = CliPlatform.currentArch();
-        var cacheDir = LocalAssetRepository.getCacheDirectory(true);
-        Files.createDirectories(cacheDir);
-
-        try (var stream = Files.list(cacheDir)) {
-            var files = stream.collect(java.util.stream.Collectors.toList());
-            for (var path : files) {
-                try {
-                    Files.delete(path);
-                } catch (java.io.IOException ignored) {
-                }
-            }
-        }
+        // Use an isolated temp dir so this test never touches the shared persistent cache.
+        var cacheDir = myFixture.getTempDirFixture().createFile("cache-placeholder").toNioPath().getParent();
 
         var binary123 = cacheDir.resolve(CliTool.AppMap.getBinaryName(platform, arch, "1.2.3"));
         Files.write(binary123, new byte[0]);
@@ -162,7 +156,7 @@ public class CliToolsTest extends AppMapBaseTest {
         Files.write(binaryInvalid, new byte[0]);
         CliTools.fixBinaryPermissions(binaryInvalid);
 
-        var highest = LocalAssetRepository.findHighestCachedBinary(CliTool.AppMap, platform, arch, true);
+        var highest = LocalAssetRepository.findHighestCachedBinaryIn(CliTool.AppMap, platform, arch, cacheDir);
         assertNotNull("Should find a fallback binary", highest);
         assertEquals("The binary with a valid SemVer should be preferred over the unparseable one",
                 binary123.toAbsolutePath(), highest.toAbsolutePath());

--- a/plugin-core/src/test/java/appland/cli/CliToolsTest.java
+++ b/plugin-core/src/test/java/appland/cli/CliToolsTest.java
@@ -74,8 +74,8 @@ public class CliToolsTest extends AppMapBaseTest {
         TestAppLandDownloadService.ensureDownloaded();
 
         var downloadedAppMapBinary = AppLandDownloadService.getInstance().getDownloadFilePath(CliTool.AppMap,
-                CliTools.currentPlatform(),
-                CliTools.currentArch());
+                CliPlatform.currentPlatform(),
+                CliPlatform.currentArch());
         assertNotNull(downloadedAppMapBinary);
 
         var bundledBinary = createMockBinary(downloadedAppMapBinary.getFileName().toString());

--- a/plugin-core/src/test/java/appland/cli/CliToolsTest.java
+++ b/plugin-core/src/test/java/appland/cli/CliToolsTest.java
@@ -25,6 +25,12 @@ public class CliToolsTest extends AppMapBaseTest {
         return false;
     }
 
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        TestAppLandDownloadService.removeDownloads();
+    }
+
     @Test
     public void bestBinarySearch() throws Exception {
         // Mock binaries to copy into the location where bundled binaries are searched
@@ -45,6 +51,9 @@ public class CliToolsTest extends AppMapBaseTest {
                 createMockBinary("appmap-macos-arm64-v1000.2.0"),
                 createMockBinary("appmap-macos-arm64-v1000.1.123")
         );
+
+        // Delete active-version to test fallback logic
+        Files.deleteIfExists(LocalAssetRepository.getToolDownloadDirectory(CliTool.AppMap, true).resolve("active-version.txt"));
 
         AppMapDeploymentTestUtils.withBundledBinaries(appmapBinaries, () -> {
             assertNotNull("There must be a match for every platform", CliTools.getBinaryPath(CliTool.AppMap));
@@ -73,10 +82,13 @@ public class CliToolsTest extends AppMapBaseTest {
     public void bundledBinaryIsPreferred() throws Exception {
         TestAppLandDownloadService.ensureDownloaded();
 
-        var downloadedAppMapBinary = AppLandDownloadService.getInstance().getDownloadFilePath(CliTool.AppMap,
+        var downloadedAppMapBinary = LocalAssetRepository.getInstalledBinaryPath(CliTool.AppMap,
                 CliPlatform.currentPlatform(),
                 CliPlatform.currentArch());
         assertNotNull(downloadedAppMapBinary);
+
+        // Delete active-version to test fallback logic
+        Files.deleteIfExists(LocalAssetRepository.getToolDownloadDirectory(CliTool.AppMap, true).resolve("active-version.txt"));
 
         var bundledBinary = createMockBinary(downloadedAppMapBinary.getFileName().toString());
 

--- a/plugin-core/src/test/java/appland/cli/CliToolsTest.java
+++ b/plugin-core/src/test/java/appland/cli/CliToolsTest.java
@@ -2,11 +2,12 @@ package appland.cli;
 
 import appland.AppMapBaseTest;
 import appland.AppMapDeploymentTestUtils;
-import appland.deployment.AppMapDeploymentSettingsService;
+import com.intellij.openapi.progress.EmptyProgressIndicator;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.nio.file.Files;
@@ -52,9 +53,6 @@ public class CliToolsTest extends AppMapBaseTest {
                 createMockBinary("appmap-macos-arm64-v1000.1.123")
         );
 
-        // Delete active-version to test fallback logic
-        Files.deleteIfExists(LocalAssetRepository.getToolDownloadDirectory(CliTool.AppMap, true).resolve("active-version.txt"));
-
         AppMapDeploymentTestUtils.withBundledBinaries(appmapBinaries, () -> {
             assertNotNull("There must be a match for every platform", CliTools.getBinaryPath(CliTool.AppMap));
 
@@ -79,31 +77,64 @@ public class CliToolsTest extends AppMapBaseTest {
     }
 
     @Test
-    public void bundledBinaryIsPreferred() throws Exception {
+    public void installedBinaryIsPreferred() throws Exception {
         TestAppLandDownloadService.ensureDownloaded();
 
-        var downloadedAppMapBinary = LocalAssetRepository.getInstalledBinaryPath(CliTool.AppMap,
-                CliPlatform.currentPlatform(),
-                CliPlatform.currentArch());
-        assertNotNull(downloadedAppMapBinary);
+        var installedBinary = LocalAssetRepository.getInstalledBinaryPath(CliTool.AppMap);
+        assertNotNull(installedBinary);
 
-        // Delete active-version to test fallback logic
-        Files.deleteIfExists(LocalAssetRepository.getToolDownloadDirectory(CliTool.AppMap, true).resolve("active-version.txt"));
-
-        var bundledBinary = createMockBinary(downloadedAppMapBinary.getFileName().toString());
-
+        // Even with a bundled binary available, the installed (symlinked) binary wins
+        var bundledBinary = createMockBinary("appmap-" + CliPlatform.currentPlatform() + "-" + CliPlatform.currentArch() + "-v9999.0.0");
         AppMapDeploymentTestUtils.withBundledBinaries(List.of(bundledBinary), () -> {
             var bestMatch = CliTools.getBinaryPath(CliTool.AppMap);
             assertNotNull(bestMatch);
-            assertEquals(bundledBinary.getFileName().toString(), bestMatch.getFileName().toString());
-
-            var binaryParentDir = AppMapDeploymentSettingsService.bundledBinarySearchPath().stream().findFirst().orElse(null);
-            assertNotNull(binaryParentDir);
-            assertEquals(
-                    "Bundled binaries should be preferred over downloaded binaries",
-                    binaryParentDir.resolve(bestMatch.getFileName()),
-                    bestMatch);
+            assertEquals("Installed binary should be preferred over bundled",
+                    installedBinary.getFileName().toString(), bestMatch.getFileName().toString());
         });
+    }
+
+    @Test
+    public void symlinkCreatedAfterDownload() throws Exception {
+        Assume.assumeFalse("symlinks are unreliable on Windows", SystemInfo.isWindows);
+
+        var symlinkPath = LocalAssetRepository.getSymlinkPath(CliTool.AppMap);
+        assertFalse("No symlink before download", Files.exists(symlinkPath));
+
+        TestAppLandDownloadService.ensureDownloaded();
+
+        assertTrue("Symlink exists after download", Files.isSymbolicLink(symlinkPath));
+        assertTrue("Symlink target is an executable binary", Files.isExecutable(symlinkPath.toRealPath()));
+
+        var version = LocalAssetRepository.getInstalledVersion(CliTool.AppMap);
+        assertNotNull("Version is readable from symlink", version);
+    }
+
+    @Test
+    public void secondDownloadIsSkipped() {
+        var service = (TestAppLandDownloadService) AppLandDownloadService.getInstance();
+        var firstStatus = service.download(CliTool.AppMap, new EmptyProgressIndicator());
+        assertEquals(AppMapDownloadStatus.Successful, firstStatus);
+
+        var secondStatus = service.download(CliTool.AppMap, new EmptyProgressIndicator());
+        assertEquals("Second download should be skipped when symlink already points to the correct binary",
+                AppMapDownloadStatus.Skipped, secondStatus);
+    }
+
+    @Test
+    public void prereleaseVersionExtractedFromSymlink() throws Exception {
+        var platform = CliPlatform.currentPlatform();
+        var arch = CliPlatform.currentArch();
+        var cacheDir = LocalAssetRepository.getCacheDirectory(true);
+        Files.createDirectories(cacheDir);
+
+        var binaryName = CliTool.AppMap.getBinaryName(platform, arch, "1.2.3-rc.1");
+        var cachedBinary = cacheDir.resolve(binaryName);
+        Files.write(cachedBinary, new byte[0]);
+        CliTools.fixBinaryPermissions(cachedBinary);
+
+        LocalAssetRepository.updateSymlink(cachedBinary, LocalAssetRepository.getSymlinkPath(CliTool.AppMap));
+
+        assertEquals("1.2.3-rc.1", LocalAssetRepository.getInstalledVersion(CliTool.AppMap));
     }
 
     private @NotNull Path createMockBinary(String filename) {

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
@@ -9,6 +9,8 @@ import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
@@ -26,10 +28,28 @@ public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
         return false;
     }
 
+    @Before
+    public void removeMockBinary() {
+        // The mock manifest uses version "1.2.3" and the download writes a fake binary to the
+        // persistent cache. Delete it before each run so isDownloaded() never short-circuits
+        // the download and the proxy assertion always holds.
+        deleteMockBinary();
+    }
+
     @AfterClass
     public static void cleanup() {
-        // we have to remote all zero-byte downloads created by this test
         TestAppLandDownloadService.removeDownloads();
+        deleteMockBinary();
+    }
+
+    private static void deleteMockBinary() {
+        var path = LocalAssetRepository.getExecutableFilePath(
+                CliTool.AppMap, "1.2.3",
+                CliPlatform.currentPlatform(), CliPlatform.currentArch(), true);
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException ignored) {
+        }
     }
 
     @After

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
@@ -45,8 +45,8 @@ public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
         // Clear manifest cache to ensure it fetches
         ManifestManager.clearCache();
 
-        var manifestUrlString = "http://localhost:" + mockServerRule.getPort() + "/manifest.json";
-        var binaryUrlString = "http://localhost:" + mockServerRule.getPort() + "/binary.bin";
+        var manifestUrlString = "http://test/manifest.json";
+        var binaryUrlString = "http://test/binary.bin";
         
         // Mock manifest endpoint
         var platformId = CliPlatform.getId();
@@ -72,9 +72,9 @@ public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
         AppLandDownloadServiceTestUtil.assertDownloadLatestCliVersions(getProject(), toolType, getTestRootDisposable());
 
         var hasManifestRequest = Arrays.stream(mockServerRule.getClient().retrieveRecordedRequests(null))
-                .anyMatch(request -> request.getPath().getValue().equals("/manifest.json"));
+                .anyMatch(request -> request.containsHeader("host", "test") && request.getPath().getValue().equals("/manifest.json"));
         var hasBinaryRequest = Arrays.stream(mockServerRule.getClient().retrieveRecordedRequests(null))
-                .anyMatch(request -> request.getPath().getValue().equals("/binary.bin"));
+                .anyMatch(request -> request.containsHeader("host", "test") && request.getPath().getValue().equals("/binary.bin"));
                 
         Assert.assertTrue("Manifest must be downloaded with the IDE's HTTP proxy", hasManifestRequest);
         Assert.assertTrue("AppMap CLI tools must be downloaded with the IDE's HTTP proxy", hasBinaryRequest);

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
@@ -14,8 +14,8 @@ import org.mockserver.model.HttpResponse;
 
 import java.util.Arrays;
 
-import static appland.cli.CliTools.currentArch;
-import static appland.cli.CliTools.currentPlatform;
+import static appland.cli.CliPlatform.currentArch;
+import static appland.cli.CliPlatform.currentPlatform;
 
 public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
     @Rule

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceProxyTest.java
@@ -3,19 +3,13 @@ package appland.cli;
 import appland.AppMapBaseTest;
 import appland.testRules.MockServerSettingsRule;
 import appland.testRules.OverrideIdeHttpProxyRule;
-import com.intellij.util.Urls;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.jetbrains.annotations.Nullable;
+import org.junit.*;
 import org.mockserver.junit.MockServerRule;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
 import java.util.Arrays;
-
-import static appland.cli.CliPlatform.currentArch;
-import static appland.cli.CliPlatform.currentPlatform;
 
 public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
     @Rule
@@ -24,6 +18,8 @@ public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
     public MockServerSettingsRule mockServerSettingsRule = new MockServerSettingsRule();
     @Rule
     public OverrideIdeHttpProxyRule ideHttpProxyRule = new OverrideIdeHttpProxyRule(mockServerRule);
+
+    private @Nullable String originalManifestUrl;
 
     @Override
     protected boolean runInDispatchThread() {
@@ -36,29 +32,51 @@ public class DefaultAppLandDownloadServiceProxyTest extends AppMapBaseTest {
         TestAppLandDownloadService.removeDownloads();
     }
 
+    @After
+    public void resetManifest() {
+        // Restore the original manifest URL after the test
+        appland.settings.AppMapApplicationSettingsService.getInstance().setAppmapManifestUrl(originalManifestUrl);
+    }
+
     @Test
     public void downloadWithHttpProxy() throws Exception {
         var toolType = CliTool.AppMap;
 
-        var latestVersion = AppLandDownloadService.getInstance().fetchLatestRemoteVersion(toolType);
-        Assert.assertNotNull(latestVersion);
+        // Clear manifest cache to ensure it fetches
+        ManifestManager.clearCache();
 
-        var binaryDownloadUrl = Urls.parse(toolType.getDownloadUrl(latestVersion, currentPlatform(), currentArch()), false);
-        Assert.assertNotNull(binaryDownloadUrl);
-
-        // override response body of the binary request to avoid OutOfMemory leaks with Mockserver
+        var manifestUrlString = "http://localhost:" + mockServerRule.getPort() + "/manifest.json";
+        var binaryUrlString = "http://localhost:" + mockServerRule.getPort() + "/binary.bin";
+        
+        // Mock manifest endpoint
+        var platformId = CliPlatform.getId();
+        var manifestJson = String.format("{\"tag_name\":\"v1.2.3\",\"assets\":[{\"name\":\"appmap-%s\",\"url\":\"%s\"}]}", platformId, binaryUrlString);
         mockServerRule.getClient()
-                .when(HttpRequest.request().withMethod("GET").withPath(binaryDownloadUrl.getPath()))
-                .respond(HttpResponse.response().withBody(""));
+                .when(HttpRequest.request().withMethod("GET").withPath("/manifest.json"))
+                .respond(HttpResponse.response().withBody(manifestJson));
+
+        // Mock binary endpoint
+        mockServerRule.getClient()
+                .when(HttpRequest.request().withMethod("GET").withPath("/binary.bin"))
+                .respond(HttpResponse.response().withBody("mock binary content"));
+
+        var settings = appland.settings.AppMapApplicationSettingsService.getInstance();
+
+        // store the original manifest URL to restore it after the test
+        originalManifestUrl = settings.getAppmapManifestUrl();
+
+        // Override the manifest URL for the test via settings
+        settings.setAppmapManifestUrlNotifying(manifestUrlString);
 
         // Perform the download using the mock HTTP proxy server
         AppLandDownloadServiceTestUtil.assertDownloadLatestCliVersions(getProject(), toolType, getTestRootDisposable());
 
-        var hasDownloadRequest = Arrays.stream(mockServerRule.getClient().retrieveRecordedRequests(null))
-                .anyMatch(request -> {
-                    var path = request.getPath().getValue();
-                    return request.containsHeader("host", binaryDownloadUrl.getAuthority()) && path.equals(binaryDownloadUrl.getPath());
-                });
-        Assert.assertTrue("AppMap CLI tools must be downloaded with the IDE's HTTP proxy", hasDownloadRequest);
+        var hasManifestRequest = Arrays.stream(mockServerRule.getClient().retrieveRecordedRequests(null))
+                .anyMatch(request -> request.getPath().getValue().equals("/manifest.json"));
+        var hasBinaryRequest = Arrays.stream(mockServerRule.getClient().retrieveRecordedRequests(null))
+                .anyMatch(request -> request.getPath().getValue().equals("/binary.bin"));
+                
+        Assert.assertTrue("Manifest must be downloaded with the IDE's HTTP proxy", hasManifestRequest);
+        Assert.assertTrue("AppMap CLI tools must be downloaded with the IDE's HTTP proxy", hasBinaryRequest);
     }
 }

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
@@ -3,13 +3,10 @@ package appland.cli;
 import appland.AppMapBaseTest;
 import appland.AppMapDeploymentTestUtils;
 import appland.deployment.AppMapDeploymentSettings;
-import com.intellij.testFramework.VfsTestUtil;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
-
-import java.util.List;
 
 public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
     @Override
@@ -41,26 +38,6 @@ public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
             var status = AppLandDownloadServiceTestUtil.downloadLatestCliVersions(getProject(), CliTool.AppMap, getTestRootDisposable());
             assertEquals(AppMapDownloadStatus.Skipped, status);
         });
-    }
-
-    @Test
-    public void findVersionedDownloadDirectories() {
-        var downloadRoot = createTempDir("downloadRoot");
-        var rootPath = downloadRoot.toNioPath();
-        assertEmpty(LocalAssetRepository.findVersionDownloadDirectories(rootPath));
-
-        // files matching the version pattern must be excluded
-        VfsTestUtil.createFile(downloadRoot, "0.0.0");
-        assertEmpty(LocalAssetRepository.findVersionDownloadDirectories(rootPath));
-
-        VfsTestUtil.createDir(downloadRoot, "1.2.3");
-        assertEquals(List.of(rootPath.resolve("1.2.3")), LocalAssetRepository.findVersionDownloadDirectories(rootPath));
-
-        VfsTestUtil.createDir(downloadRoot, "something-else");
-        assertEquals(List.of(rootPath.resolve("1.2.3")), LocalAssetRepository.findVersionDownloadDirectories(rootPath));
-
-        assertEmpty(LocalAssetRepository.removeOtherVersions(rootPath, "1.2.3"));
-        assertEquals(List.of(rootPath.resolve("1.2.3")), LocalAssetRepository.removeOtherVersions(rootPath, "9.9.9"));
     }
 
     private static void assertDownloadPath(@NotNull CliTool type) {

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
@@ -55,20 +55,20 @@ public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
     public void findVersionedDownloadDirectories() {
         var downloadRoot = createTempDir("downloadRoot");
         var rootPath = downloadRoot.toNioPath();
-        assertEmpty(DefaultAppLandDownloadService.findVersionDownloadDirectories(rootPath));
+        assertEmpty(LocalAssetRepository.findVersionDownloadDirectories(rootPath));
 
         // files matching the version pattern must be excluded
         VfsTestUtil.createFile(downloadRoot, "0.0.0");
-        assertEmpty(DefaultAppLandDownloadService.findVersionDownloadDirectories(rootPath));
+        assertEmpty(LocalAssetRepository.findVersionDownloadDirectories(rootPath));
 
         VfsTestUtil.createDir(downloadRoot, "1.2.3");
-        assertEquals(List.of(rootPath.resolve("1.2.3")), DefaultAppLandDownloadService.findVersionDownloadDirectories(rootPath));
+        assertEquals(List.of(rootPath.resolve("1.2.3")), LocalAssetRepository.findVersionDownloadDirectories(rootPath));
 
         VfsTestUtil.createDir(downloadRoot, "something-else");
-        assertEquals(List.of(rootPath.resolve("1.2.3")), DefaultAppLandDownloadService.findVersionDownloadDirectories(rootPath));
+        assertEquals(List.of(rootPath.resolve("1.2.3")), LocalAssetRepository.findVersionDownloadDirectories(rootPath));
 
-        assertEmpty(DefaultAppLandDownloadService.removeOtherVersions(rootPath, "1.2.3"));
-        assertEquals(List.of(rootPath.resolve("1.2.3")), DefaultAppLandDownloadService.removeOtherVersions(rootPath, "9.9.9"));
+        assertEmpty(LocalAssetRepository.removeOtherVersions(rootPath, "1.2.3"));
+        assertEquals(List.of(rootPath.resolve("1.2.3")), LocalAssetRepository.removeOtherVersions(rootPath, "9.9.9"));
     }
 
     @Test
@@ -81,8 +81,8 @@ public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
     }
 
     private static void assertDownloadPath(@NotNull CliTool type) {
-        assertNotNull(DefaultAppLandDownloadService.getToolDownloadDirectory(type, true));
-        assertNotNull(DefaultAppLandDownloadService.getToolDownloadDirectory(type, false));
+        assertNotNull(LocalAssetRepository.getToolDownloadDirectory(type, true));
+        assertNotNull(LocalAssetRepository.getToolDownloadDirectory(type, false));
     }
 
     private static void assertVersion(@NotNull CliTool type) throws IOException {

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
@@ -2,11 +2,13 @@ package appland.cli;
 
 import appland.AppMapBaseTest;
 import appland.AppMapDeploymentTestUtils;
+import appland.RequiresNetwork;
 import appland.deployment.AppMapDeploymentSettings;
 import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
     @Override
@@ -25,6 +27,7 @@ public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
         assertDownloadPath(CliTool.Scanner);
     }
 
+    @Category(RequiresNetwork.class)
     @Test
     public void downloadAppMapBinary() throws Exception {
         // We're only testing the download of the AppMap tool and not of the scanner

--- a/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultAppLandDownloadServiceTest.java
@@ -9,9 +9,7 @@ import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.List;
-import java.util.regex.Pattern;
 
 public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
     @Override
@@ -22,12 +20,6 @@ public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
     @Override
     protected TempDirTestFixture createTempDirTestFixture() {
         return new TempDirTestFixtureImpl();
-    }
-
-    @Test
-    public void latestVersion() throws IOException {
-        assertVersion(CliTool.AppMap);
-        assertVersion(CliTool.Scanner);
     }
 
     @Test
@@ -45,7 +37,7 @@ public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
 
     @Test
     public void downloadAppMapBinaryWithProhibitingDeploymentSettings() throws Exception {
-        AppMapDeploymentTestUtils.withSiteConfigFile(new AppMapDeploymentSettings(null, false), () -> {
+        AppMapDeploymentTestUtils.withSiteConfigFile(new AppMapDeploymentSettings(null, false, null, null), () -> {
             var status = AppLandDownloadServiceTestUtil.downloadLatestCliVersions(getProject(), CliTool.AppMap, getTestRootDisposable());
             assertEquals(AppMapDownloadStatus.Skipped, status);
         });
@@ -71,23 +63,8 @@ public class DefaultAppLandDownloadServiceTest extends AppMapBaseTest {
         assertEquals(List.of(rootPath.resolve("1.2.3")), LocalAssetRepository.removeOtherVersions(rootPath, "9.9.9"));
     }
 
-    @Test
-    public void parseLatestVersion() {
-        var json = "[{\"tag_name\": \"@appland/appmap-validate-v1.0.0\"}, {\"tag_name\": \"@appland/scanner-v1.2.3\"}, {\"tag_name\": \"@appland/appmap-v4.5.6\"}]";
-        var releases = com.google.gson.JsonParser.parseString(json).getAsJsonArray();
-
-        assertEquals("4.5.6", DefaultAppLandDownloadService.parseLatestVersion(CliTool.AppMap, releases));
-        assertEquals("1.2.3", DefaultAppLandDownloadService.parseLatestVersion(CliTool.Scanner, releases));
-    }
-
     private static void assertDownloadPath(@NotNull CliTool type) {
         assertNotNull(LocalAssetRepository.getToolDownloadDirectory(type, true));
         assertNotNull(LocalAssetRepository.getToolDownloadDirectory(type, false));
-    }
-
-    private static void assertVersion(@NotNull CliTool type) throws IOException {
-        var version = AppLandDownloadService.getInstance().fetchLatestRemoteVersion(type);
-        assertNotNull(version);
-        assertTrue(Pattern.matches("\\d+\\.\\d+\\.\\d+", version));
     }
 }

--- a/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
+++ b/plugin-core/src/test/java/appland/cli/DefaultCommandLineServiceTest.java
@@ -1,6 +1,7 @@
 package appland.cli;
 
 import appland.AppMapBaseTest;
+import appland.RequiresNetwork;
 import appland.files.AppMapFiles;
 import appland.settings.AppMapApplicationSettingsService;
 import appland.settings.AppMapSettingsListener;
@@ -27,6 +28,7 @@ import com.intellij.util.net.HttpConfigurable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 
 import java.nio.file.Files;
@@ -41,6 +43,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 @SuppressWarnings("removal")
+@Category(RequiresNetwork.class)
 public class DefaultCommandLineServiceTest extends AppMapBaseTest {
     @Rule
     public final TestRule resetProxyRule = new ResetIdeHttpProxyRule();

--- a/plugin-core/src/test/java/appland/cli/ManifestTest.java
+++ b/plugin-core/src/test/java/appland/cli/ManifestTest.java
@@ -1,0 +1,60 @@
+package appland.cli;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ManifestTest {
+
+    @Test
+    public void testParseValidManifest() {
+        var json = """
+                {
+                  "tag_name": "v1.2.3",
+                  "assets": [
+                    {
+                      "name": "appmap-linux-x64",
+                      "url": "https://example.com/appmap-linux-x64",
+                      "digest": "sha256:12345"
+                    },
+                    {
+                      "name": "appmap-win-x64.exe",
+                      "url": "https://example.com/appmap-win-x64.exe",
+                      "digest": "sha256:67890"
+                    }
+                  ]
+                }
+                """;
+        var manifest = Manifest.parse(json);
+        assertNotNull(manifest);
+        assertEquals("1.2.3", manifest.version);
+
+        var linuxAsset = manifest.getAsset("linux-x64");
+        assertNotNull(linuxAsset);
+        assertEquals("https://example.com/appmap-linux-x64", linuxAsset.url);
+        assertEquals("sha256:12345", linuxAsset.digest);
+
+        var winAsset = manifest.getAsset("win-x64");
+        assertNotNull(winAsset);
+        assertEquals("https://example.com/appmap-win-x64.exe", winAsset.url);
+        assertEquals("sha256:67890", winAsset.digest);
+    }
+
+    @Test
+    public void testParseInvalidVersion() {
+        var json = """
+                {
+                  "tag_name": "invalid",
+                  "assets": []
+                }
+                """;
+        var manifest = Manifest.parse(json);
+        assertNull(manifest);
+    }
+
+    @Test
+    public void testParseMissingFields() {
+        var manifest = Manifest.parse("{}");
+        assertNull(manifest);
+    }
+}

--- a/plugin-core/src/test/java/appland/cli/SemVerComparatorTest.java
+++ b/plugin-core/src/test/java/appland/cli/SemVerComparatorTest.java
@@ -9,8 +9,8 @@ public class SemVerComparatorTest extends AppMapBaseTest {
     public void comparator() {
         var comparator = SemVerComparator.INSTANCE;
         assertEquals(0, comparator.compare(SemVer.parseFromText("1.2.3"), SemVer.parseFromText("1.2.3")));
-        assertEquals(1, comparator.compare(null, SemVer.parseFromText("1.2.3")));
-        assertEquals(-1, comparator.compare(SemVer.parseFromText("1.2.3"), null));
+        assertEquals(-1, comparator.compare(null, SemVer.parseFromText("1.2.3")));
+        assertEquals(1, comparator.compare(SemVer.parseFromText("1.2.3"), null));
 
         assertEquals(1, comparator.compare(SemVer.parseFromText("2.0.0"), SemVer.parseFromText("1.2.3")));
         assertEquals(-1, comparator.compare(SemVer.parseFromText("1.2.3"), SemVer.parseFromText("2.0.0")));

--- a/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
+++ b/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
@@ -6,7 +6,7 @@ import com.intellij.openapi.util.io.NioFiles;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.List;
 
 /**
  * Customized download service for tests.
@@ -26,12 +26,13 @@ public class TestAppLandDownloadService extends DefaultAppLandDownloadService {
             throw new IllegalStateException("This method can only be called in unit test mode");
         }
 
-        Path cacheDir = LocalAssetRepository.getCacheDirectory(true);
-        if (Files.exists(cacheDir)) {
-            try {
-                NioFiles.deleteRecursively(cacheDir);
-            } catch (IOException e) {
-                // ignore
+        for (var dir : List.of(LocalAssetRepository.getCacheDirectory(true), LocalAssetRepository.getBinDirectory())) {
+            if (Files.exists(dir)) {
+                try {
+                    NioFiles.deleteRecursively(dir);
+                } catch (IOException e) {
+                    // ignore
+                }
             }
         }
     }

--- a/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
+++ b/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.util.io.NioFiles;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Customized download service for tests.
@@ -25,14 +26,12 @@ public class TestAppLandDownloadService extends DefaultAppLandDownloadService {
             throw new IllegalStateException("This method can only be called in unit test mode");
         }
 
-        for (var type : CliTool.values()) {
-            var downloadDir = LocalAssetRepository.getToolDownloadDirectory(type, true);
-            if (Files.exists(downloadDir)) {
-                try {
-                    NioFiles.deleteRecursively(downloadDir);
-                } catch (IOException e) {
-                    // ignore
-                }
+        Path cacheDir = LocalAssetRepository.getCacheDirectory(true);
+        if (Files.exists(cacheDir)) {
+            try {
+                NioFiles.deleteRecursively(cacheDir);
+            } catch (IOException e) {
+                // ignore
             }
         }
     }

--- a/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
+++ b/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
@@ -29,7 +29,7 @@ public class TestAppLandDownloadService extends DefaultAppLandDownloadService {
         }
 
         for (var type : CliTool.values()) {
-            var downloadDir = TestAppLandDownloadService.getToolDownloadDirectory(type, true);
+            var downloadDir = LocalAssetRepository.getToolDownloadDirectory(type, true);
             if (Files.exists(downloadDir)) {
                 try {
                     NioFiles.deleteRecursively(downloadDir);

--- a/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
+++ b/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
@@ -14,11 +14,8 @@ public class TestAppLandDownloadService extends DefaultAppLandDownloadService {
     public static void ensureDownloaded() {
         var service = (TestAppLandDownloadService) AppLandDownloadService.getInstance();
         for (var type : CliTool.values()) {
-            if (service.findLatestDownloadedVersion(type) == null) {
-                var version = service.fetchLatestRemoteVersion(type);
-                assert version != null;
-
-                service.download(type, version, new EmptyProgressIndicator());
+            if (LocalAssetRepository.getInstalledVersion(type) == null) {
+                service.download(type, new EmptyProgressIndicator());
             }
         }
     }

--- a/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
+++ b/plugin-core/src/test/java/appland/cli/TestAppLandDownloadService.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.util.io.NioFiles;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.List;
 
 /**
  * Customized download service for tests.
@@ -21,18 +20,50 @@ public class TestAppLandDownloadService extends DefaultAppLandDownloadService {
         }
     }
 
+    /**
+     * Places a zero-byte executable stub for each CLI tool so tests that only need a binary to
+     * exist at the installed path can run without hitting the network.
+     */
+    public static void ensureStubInstalled() {
+        var platform = CliPlatform.currentPlatform();
+        var arch = CliPlatform.currentArch();
+        for (var type : CliTool.values()) {
+            if (LocalAssetRepository.getInstalledBinaryPath(type) != null) {
+                continue;
+            }
+            try {
+                var cacheDir = LocalAssetRepository.getCacheDirectory(true);
+                Files.createDirectories(cacheDir);
+                // "stub" starts with a non-digit, so versionFromCachedFilename returns null and
+                // findHighestCachedBinary ignores this file entirely.
+                var stubPath = LocalAssetRepository.getExecutableFilePath(type, "stub", platform, arch, true);
+                if (!Files.exists(stubPath)) {
+                    Files.write(stubPath, new byte[0]);
+                    CliTools.fixBinaryPermissions(stubPath);
+                }
+                LocalAssetRepository.updateSymlink(stubPath, LocalAssetRepository.getSymlinkPath(type));
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to install stub binary for " + type, e);
+            }
+        }
+    }
+
+    /**
+     * Removes the current-version symlinks so each test starts with a clean installed state.
+     * The persistent binary cache is intentionally left intact so downloaded binaries survive
+     * across test invocations and are not re-fetched unnecessarily.
+     */
     public static void removeDownloads() {
         if (!ApplicationManager.getApplication().isUnitTestMode()) {
             throw new IllegalStateException("This method can only be called in unit test mode");
         }
 
-        for (var dir : List.of(LocalAssetRepository.getCacheDirectory(true), LocalAssetRepository.getBinDirectory())) {
-            if (Files.exists(dir)) {
-                try {
-                    NioFiles.deleteRecursively(dir);
-                } catch (IOException e) {
-                    // ignore
-                }
+        var binDir = LocalAssetRepository.getBinDirectory();
+        if (Files.exists(binDir)) {
+            try {
+                NioFiles.deleteRecursively(binDir);
+            } catch (IOException e) {
+                // ignore
             }
         }
     }

--- a/plugin-core/src/test/java/appland/deployment/AppMapDeploymentSettingsTest.java
+++ b/plugin-core/src/test/java/appland/deployment/AppMapDeploymentSettingsTest.java
@@ -9,7 +9,7 @@ public class AppMapDeploymentSettingsTest extends AppMapBaseTest {
     public void jsonSerialization() {
         var settings = new AppMapDeploymentSettings(new AppMapDeploymentTelemetrySettings(
                 "splunk", "https://my-splunk.example.com:443", "my-hec-token", "my-ca-cert"
-        ), true);
+        ), true, null, null);
 
         var expectedJson = """
                 {"appMap.telemetry":{"backend":"splunk","url":"https://my-splunk.example.com:443","token":"my-hec-token","ca":"my-ca-cert"},"appMap.autoUpdateTools":true}

--- a/plugin-core/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceTest.java
+++ b/plugin-core/src/test/java/appland/javaAgent/AppMapJavaAgentDownloadServiceTest.java
@@ -1,6 +1,7 @@
 package appland.javaAgent;
 
 import appland.AppMapBaseTest;
+import appland.RequiresNetwork;
 import appland.utils.SystemProperties;
 import com.intellij.openapi.progress.EmptyProgressIndicator;
 import com.intellij.openapi.util.SystemInfo;
@@ -8,6 +9,7 @@ import com.intellij.testFramework.fixtures.TempDirTestFixture;
 import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 
 import java.io.IOException;
@@ -37,6 +39,7 @@ public class AppMapJavaAgentDownloadServiceTest extends AppMapBaseTest {
         assertTrue("Agent dir must be under ~/.agent", agentDir.startsWith(expectedParent));
     }
 
+    @Category(RequiresNetwork.class)
     @Test
     public void multipleDownloadRequests() throws IOException {
         var service = AppMapJavaAgentDownloadService.getInstance();
@@ -52,6 +55,7 @@ public class AppMapJavaAgentDownloadServiceTest extends AppMapBaseTest {
         assertNotNull("JAR file must still exist after a skipped download", service.getJavaAgentPathIfExists());
     }
 
+    @Category(RequiresNetwork.class)
     @Test
     public void lockFileGuard() throws IOException {
         var service = AppMapJavaAgentDownloadService.getInstance();

--- a/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
+++ b/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
@@ -30,10 +30,13 @@ import static org.junit.Assert.assertArrayEquals;
 public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
     @Before
     public void setupListener() {
-        // by default, the listener is inactive in test mode to avoid side-effects
+        // by default, the listener is inactive in test mode to avoid side-effects;
+        // pass getTestRootDisposable() so alarms are cancelled when the test ends and
+        // don't trigger unexpected restarts in subsequent tests
+        var listener = new AppMapSettingsReloadProjectListener(getTestRootDisposable());
         ApplicationManager.getApplication().getMessageBus()
                 .connect(getTestRootDisposable())
-                .subscribe(AppMapSettingsListener.TOPIC, new AppMapSettingsReloadProjectListener());
+                .subscribe(AppMapSettingsListener.TOPIC, listener);
     }
 
     @Override

--- a/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
+++ b/plugin-core/src/test/java/appland/rpcService/DefaultAppLandJsonRpcServiceTest.java
@@ -1,6 +1,7 @@
 package appland.rpcService;
 
 import appland.AppMapBaseTest;
+import appland.RequiresNetwork;
 import appland.cli.AppLandCommandLineService;
 import appland.cli.TestAppLandDownloadService;
 import appland.settings.AppMapApplicationSettingsService;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.Collection;
 import java.util.Map;
@@ -27,6 +29,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertArrayEquals;
 
+@Category(RequiresNetwork.class)
 public class DefaultAppLandJsonRpcServiceTest extends AppMapBaseTest {
     @Before
     public void setupListener() {

--- a/plugin-core/src/test/java/appland/testRules/OverrideIdeHttpProxyRule.java
+++ b/plugin-core/src/test/java/appland/testRules/OverrideIdeHttpProxyRule.java
@@ -1,6 +1,7 @@
 package appland.testRules;
 
-import com.intellij.util.net.HttpConfigurable;
+import com.intellij.util.net.ProxyConfiguration;
+import com.intellij.util.net.ProxySettings;
 import org.jetbrains.annotations.NotNull;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -19,21 +20,15 @@ public final class OverrideIdeHttpProxyRule implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                var settings = HttpConfigurable.getInstance();
-                var wasHttpProxy = settings.USE_HTTP_PROXY;
-                var wasProxyHost = settings.PROXY_HOST;
-                var wasProxyPort = settings.PROXY_PORT;
+                var settings = ProxySettings.getInstance();
+                var originalConfig = settings.getProxyConfiguration();
 
                 try {
-                    settings.USE_HTTP_PROXY = true;
-                    settings.PROXY_HOST = "127.0.0.1";
-                    settings.PROXY_PORT = mockServerRule.getPort();
+                    settings.setProxyConfiguration(ProxyConfiguration.proxy(ProxyConfiguration.ProxyProtocol.HTTP, "127.0.0.1", mockServerRule.getPort(), ""));
 
                     statement.evaluate();
                 } finally {
-                    settings.USE_HTTP_PROXY = wasHttpProxy;
-                    settings.PROXY_HOST = wasProxyHost;
-                    settings.PROXY_PORT = wasProxyPort;
+                    settings.setProxyConfiguration(originalConfig);
                 }
             }
         };


### PR DESCRIPTION
This changes the download strategy of CLI/scanner to use [release manifests](https://github.com/getappmap/appmap-js/blob/7da8f9bd04cf52c691f9e1bba1c91307c9e44646/architecture/release-manifests.md) – this aligns with [recent change in VSCode](https://github.com/getappmap/vscode-appland/pull/1110) and allows overriding the manifest locations to enable enterprise mirroring.

The changeset also includes refactoring of the asset download code and changes the download cache and binary location to the convention used by the VSCode extension. This prevents having to redownload the binaries if the user uses both IDEs (or indeed several different versions of intellij).