### PR TITLE
fix: load missing dependency map stylesheet in JetBrains webview

### DIFF
--- a/appland-webview/appmap.html
+++ b/appland-webview/appmap.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="./dist/appmap.css"/>
     <link rel="stylesheet" href="ide-styles.css"/>
   <title>AppLand Scenario</title>
 </head>


### PR DESCRIPTION
The Dependency Map is almost blank in the JetBrains plugin while the same AppMap renders correctly in VS Code.

The webview bundle already contains dist/appmap.css, but appmap.html does not load it explicitly. This change adds the missing stylesheet reference.

Tested with:
- IntelliJ IDEA 2026.1 platform
- Gradle task: clean buildPlugin -PplatformVersion=261
- Existing .appmap.json file that renders correctly in VS Code